### PR TITLE
Ignore test run output from Cypress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ locale/**/*.js
 dumped.sql
 
 /utils/data/patrons.json
+
+# cypress
+cypress/videos/*
+cypress/screenshots/*


### PR DESCRIPTION
Related to #85. Right now, running `npm run cy:run` creates output screenshots and/or videos that might accidentally get committed to Git.