### PR TITLE
Unset width for popover in navigation

### DIFF
--- a/components/layout/IconNavBar.tsx
+++ b/components/layout/IconNavBar.tsx
@@ -242,7 +242,7 @@ const IconNavBar = () => {
             {children}
           </Flex>
         </PopoverTrigger>
-        <PopoverContent bg={secondaryBgColor} w="unset">
+        <PopoverContent bg={secondaryBgColor}>
           <PopoverHeader fontWeight="semibold">{displayName}</PopoverHeader>
           <PopoverArrow bg={secondaryBgColor} />
         </PopoverContent>

--- a/components/layout/IconNavBar.tsx
+++ b/components/layout/IconNavBar.tsx
@@ -242,7 +242,7 @@ const IconNavBar = () => {
             {children}
           </Flex>
         </PopoverTrigger>
-        <PopoverContent bg={secondaryBgColor}>
+        <PopoverContent bg={secondaryBgColor} w="unset">
           <PopoverHeader fontWeight="semibold">{displayName}</PopoverHeader>
           <PopoverArrow bg={secondaryBgColor} />
         </PopoverContent>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -102,7 +102,7 @@ const extendedTheme = extendTheme({
     Popover: {
       variants: {
         responsive: {
-          popper: {
+          content: {
             maxWidth: "unset",
             width: "unset",
           },


### PR DESCRIPTION
#388 
It allows to ignore chakra-ui variable for width (20rem) and use width depending on content size.
Also `min-width: max-content` can be useful if smth goes wrong with this solution.