### PR TITLE
Add title to ability icon as helper text

### DIFF
--- a/components/builds/APStats.tsx
+++ b/components/builds/APStats.tsx
@@ -1,3 +1,4 @@
+import { Ability } from ".prisma/client";
 import { Flex } from "@chakra-ui/react";
 import { Trans } from "@lingui/macro";
 import AbilityIcon from "components/common/AbilityIcon";
@@ -14,7 +15,7 @@ import { mainOnlyAbilities } from "utils/lists/abilities";
 
 interface Props {
   stats: {
-    code: string;
+    code: Ability;
     average: number;
     counts: number[][];
   }[];

--- a/components/common/AbilityIcon.tsx
+++ b/components/common/AbilityIcon.tsx
@@ -1,5 +1,6 @@
 import { Box } from "@chakra-ui/react";
 import Image from "next/image";
+import { abilities } from "utils/lists/abilities";
 
 //https://github.com/loadout-ink/splat2-calc
 
@@ -10,10 +11,12 @@ const sizeMap = {
   SUBTINY: 20,
 } as const;
 
+type AbilityMap = typeof abilities[number];
+type AbilityCode = AbilityMap["code"];
+
 interface AbilityIconProps {
-  // TODO: use enum from generated/graphql.tsx
-  ability: string | "EMPTY";
-  size: "MAIN" | "SUB" | "TINY" | "SUBTINY";
+  ability: AbilityCode | "UNKNOWN";
+  size: keyof typeof sizeMap;
   loading?: "eager";
 }
 
@@ -23,6 +26,7 @@ const AbilityIcon: React.FC<AbilityIconProps> = ({
   loading,
 }) => {
   const sizeNumber = sizeMap[size];
+  const abilityName = abilities.find((a) => a.code === ability)?.name;
 
   return (
     <Box
@@ -45,8 +49,9 @@ const AbilityIcon: React.FC<AbilityIconProps> = ({
         src={`/abilityIcons/${ability}.png`}
         width={sizeNumber}
         height={sizeNumber}
-        alt={ability}
+        alt={abilityName}
         loading={loading ?? "lazy"}
+        title={abilityName}
       />
     </Box>
   );

--- a/components/common/AbilityIcon.tsx
+++ b/components/common/AbilityIcon.tsx
@@ -1,3 +1,4 @@
+import { Ability } from ".prisma/client";
 import { Box } from "@chakra-ui/react";
 import Image from "next/image";
 import { abilities } from "utils/lists/abilities";
@@ -11,11 +12,8 @@ const sizeMap = {
   SUBTINY: 20,
 } as const;
 
-type AbilityMap = typeof abilities[number];
-type AbilityCode = AbilityMap["code"];
-
 interface AbilityIconProps {
-  ability: AbilityCode | "UNKNOWN";
+  ability: Ability | "UNKNOWN";
   size: keyof typeof sizeMap;
   loading?: "eager";
 }

--- a/hooks/builds.ts
+++ b/hooks/builds.ts
@@ -224,7 +224,7 @@ export function useBuildsByWeapon() {
   )
     .map(([abilityCode, apCounts]) => {
       return {
-        code: abilityCode,
+        code: abilityCode as Ability,
         average:
           Object.entries(apCounts).reduce(
             (acc, cur) => Number(cur[0]) * cur[1] + acc,


### PR DESCRIPTION
## What I did

I can't always remember what each icon is for the ability chunks (mostly on the build analyzer page) so I'm adding a title to the `Image` component in `AbilityIcon` so on hover some helper text appears with the full name of the ability.

This also improves the type definitions and provides a slight accessibility improvement as well.

## How to test

Pull down and verify pages that utilize the `AbilityIcon` component shows the name of the ability on hover.

![Screen Recording 2021-04-10 at 2 23 16 PM](https://user-images.githubusercontent.com/1447644/114286161-def30980-9a21-11eb-9f57-134c3d419076.gif)


