### PR TITLE
Maplist generator: Add option to display map pool as table

### DIFF
--- a/components/common/NewTable.tsx
+++ b/components/common/NewTable.tsx
@@ -14,7 +14,7 @@ import React, { Fragment } from "react";
 import { getRankingString } from "utils/strings";
 import OutlinedBox from "./OutlinedBox";
 
-type TableRow = Record<string, React.ReactNode> & { id: number };
+export type TableRow = Record<string, React.ReactNode> & { id: number };
 
 export default function NewTable({
   caption,

--- a/components/common/NewTable.tsx
+++ b/components/common/NewTable.tsx
@@ -14,6 +14,8 @@ import React, { Fragment } from "react";
 import { getRankingString } from "utils/strings";
 import OutlinedBox from "./OutlinedBox";
 
+type TableRow = Record<string, React.ReactNode> & { id: number };
+
 export default function NewTable({
   caption,
   headers,
@@ -27,7 +29,7 @@ export default function NewTable({
     name: string;
     dataKey: string;
   }[];
-  data: ((Record<string, React.ReactNode> & { id: number }) | null)[];
+  data: (TableRow | null)[];
   smallAtPx?: string;
   leaderboardKey?: string;
   size?: "sm" | "md" | "lg"
@@ -36,17 +38,15 @@ export default function NewTable({
     smallAtPx ? `(max-width: ${smallAtPx}px)` : "(max-width: 600px)"
   );
 
+  const nonNullData = data.filter((row): row is TableRow => row !== null);
+
   let lastValue: any = null;
   let rankToUse: number = 1;
 
   if (isSmall) {
     return (
       <>
-        {data.map((row, i) => {
-          if (row === null) {
-            return;
-          }
-
+        {nonNullData.map((row, i) => {
           if (leaderboardKey) {
             if (row[leaderboardKey] !== lastValue) rankToUse = i + 1;
             lastValue = row[leaderboardKey];
@@ -119,11 +119,7 @@ export default function NewTable({
           </Tr>
         </Thead>
         <Tbody>
-          {data.map((row, i) => {
-            if (row === null) {
-              return;
-            }
-
+          {nonNullData.map((row, i) => {
             if (leaderboardKey) {
               if (row[leaderboardKey] !== lastValue) rankToUse = i + 1;
               lastValue = row[leaderboardKey];

--- a/components/common/NewTable.tsx
+++ b/components/common/NewTable.tsx
@@ -22,7 +22,7 @@ export default function NewTable({
   data,
   smallAtPx,
   leaderboardKey,
-  size
+  size,
 }: {
   caption?: string;
   headers: {
@@ -32,7 +32,7 @@ export default function NewTable({
   data: (TableRow | null)[];
   smallAtPx?: string;
   leaderboardKey?: string;
-  size?: "sm" | "md" | "lg"
+  size?: "sm" | "md" | "lg";
 }) {
   const [isSmall] = useMediaQuery(
     smallAtPx ? `(max-width: ${smallAtPx}px)` : "(max-width: 600px)"
@@ -108,7 +108,7 @@ export default function NewTable({
 
   return (
     <OutlinedBox>
-      <Table variant="simple" fontSize="sm" size={size ? size : 'md'}>
+      <Table variant="simple" fontSize="sm" size={size ? size : "md"}>
         {caption && <TableCaption placement="top">{caption}</TableCaption>}
         <Thead>
           <Tr>

--- a/components/common/NewTable.tsx
+++ b/components/common/NewTable.tsx
@@ -108,7 +108,7 @@ export default function NewTable({
 
   return (
     <OutlinedBox>
-      <Table variant="simple" fontSize="sm" size={size ? size : "md"}>
+      <Table variant="simple" fontSize="sm" size={size ?? "md"}>
         {caption && <TableCaption placement="top">{caption}</TableCaption>}
         <Thead>
           <Tr>

--- a/components/common/NewTable.tsx
+++ b/components/common/NewTable.tsx
@@ -20,15 +20,17 @@ export default function NewTable({
   data,
   smallAtPx,
   leaderboardKey,
+  size
 }: {
   caption?: string;
   headers: {
     name: string;
     dataKey: string;
   }[];
-  data: (Record<string, React.ReactNode> & { id: number })[];
+  data: ((Record<string, React.ReactNode> & { id: number }) | null)[];
   smallAtPx?: string;
   leaderboardKey?: string;
+  size?: "sm" | "md" | "lg"
 }) {
   const [isSmall] = useMediaQuery(
     smallAtPx ? `(max-width: ${smallAtPx}px)` : "(max-width: 600px)"
@@ -41,6 +43,10 @@ export default function NewTable({
     return (
       <>
         {data.map((row, i) => {
+          if (row === null) {
+            return;
+          }
+
           if (leaderboardKey) {
             if (row[leaderboardKey] !== lastValue) rankToUse = i + 1;
             lastValue = row[leaderboardKey];
@@ -102,7 +108,7 @@ export default function NewTable({
 
   return (
     <OutlinedBox>
-      <Table variant="simple" fontSize="sm">
+      <Table variant="simple" fontSize="sm" size={size ? size : 'md'}>
         {caption && <TableCaption placement="top">{caption}</TableCaption>}
         <Thead>
           <Tr>
@@ -114,6 +120,10 @@ export default function NewTable({
         </Thead>
         <Tbody>
           {data.map((row, i) => {
+            if (row === null) {
+              return;
+            }
+
             if (leaderboardKey) {
               if (row[leaderboardKey] !== lastValue) rankToUse = i + 1;
               lastValue = row[leaderboardKey];

--- a/components/maps/MapPoolDisplay.tsx
+++ b/components/maps/MapPoolDisplay.tsx
@@ -32,6 +32,29 @@ function getTableData(
   );
 }
 
+function getGridModeCells(
+  stagesSelected: Record<string, RankedMode[]>
+): JSX.Element[] {
+  return Object.values(RankedMode).map((mode) => {
+    return (
+      <div key={mode}>
+        <Box textAlign="center">
+          <ModeImage mode={mode} />
+        </Box>
+        <Box textAlign="center">
+          {Object.entries(stagesSelected).map(([stage, modes]) =>
+            modes.includes(mode) ? (
+              <SubText key={stage} mb={1}>
+                {t({ id: stage })}
+              </SubText>
+            ) : null
+          )}
+        </Box>
+      </div>
+    );
+  });
+}
+
 export function MapPoolDisplay({
   stagesSelected,
 }: {
@@ -42,51 +65,12 @@ export function MapPoolDisplay({
   return isMobile ? (
     <Grid
       mb={8}
-      templateColumns="repeat(4, 1fr)"
+      templateColumns={{ base: "repeat(2, 1fr)", sm: "repeat(4, 1fr)" }}
       rowGap={4}
       columnGap={4}
       display="grid"
     >
-      <Box textAlign="center">
-        <ModeImage mode="SZ" />
-      </Box>
-      <Box textAlign="center">
-        <ModeImage mode="TC" />
-      </Box>
-      <Box textAlign="center">
-        <ModeImage mode="RM" />
-      </Box>
-      <Box textAlign="center">
-        <ModeImage mode="CB" />
-      </Box>
-      <Box textAlign="center">
-        {Object.entries(stagesSelected).map(([stage, modes]) =>
-          modes.includes("SZ") ? (
-            <SubText key={stage}>{t({ id: stage })}</SubText>
-          ) : null
-        )}
-      </Box>
-      <Box textAlign="center">
-        {Object.entries(stagesSelected).map(([stage, modes]) =>
-          modes.includes("TC") ? (
-            <SubText key={stage}>{t({ id: stage })}</SubText>
-          ) : null
-        )}
-      </Box>
-      <Box textAlign="center">
-        {Object.entries(stagesSelected).map(([stage, modes]) =>
-          modes.includes("RM") ? (
-            <SubText key={stage}>{t({ id: stage })}</SubText>
-          ) : null
-        )}
-      </Box>
-      <Box textAlign="center">
-        {Object.entries(stagesSelected).map(([stage, modes]) =>
-          modes.includes("CB") ? (
-            <SubText key={stage}>{t({ id: stage })}</SubText>
-          ) : null
-        )}
-      </Box>
+      {getGridModeCells(stagesSelected)}
     </Grid>
   ) : (
     <NewTable

--- a/components/maps/MapPoolDisplay.tsx
+++ b/components/maps/MapPoolDisplay.tsx
@@ -5,7 +5,32 @@ import SubText from "../common/SubText";
 import { t } from "@lingui/macro";
 import { FaCheck } from "react-icons/fa";
 import { CSSVariables } from "../../utils/CSSVariables";
-import NewTable from "../common/NewTable";
+import NewTable, { TableRow } from "../common/NewTable";
+
+function getModeCells(
+  enabledModes: RankedMode[]
+): { [mode in RankedMode]: JSX.Element | null } {
+  return Object.values(RankedMode).reduce((map, mode) => {
+    map[mode] = enabledModes.includes(mode) ? (
+      <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} />
+    ) : null;
+    return map;
+  }, {} as { [mode in RankedMode]: JSX.Element | null });
+}
+
+function getTableData(
+  stagesSelected: Record<string, RankedMode[]>
+): (TableRow | null)[] {
+  return Object.entries(stagesSelected).map(([stage, modes], index) =>
+    modes.length > 0
+      ? {
+          id: index,
+          stage: t({ id: stage }),
+          ...getModeCells(modes),
+        }
+      : null
+  );
+}
 
 export function MapPoolDisplay({
   stagesSelected,
@@ -73,23 +98,7 @@ export function MapPoolDisplay({
         { name: t`Rainmaker`, dataKey: RankedMode.RM },
         { name: t`Clam Blitz`, dataKey: RankedMode.CB },
       ]}
-      data={Object.entries(stagesSelected).map(([stage, modes], index) =>
-        modes.length > 0
-          ? {
-              id: index,
-              stage: t({ id: stage }),
-              ...Object.values(RankedMode).reduce((map, mode) => {
-                map[mode] = modes.includes(mode) ? (
-                  <FaCheck
-                    color={CSSVariables.themeColor}
-                    style={{ margin: "auto" }}
-                  />
-                ) : null;
-                return map;
-              }, {} as { [mode in RankedMode]: JSX.Element | null }),
-            }
-          : null
-      )}
+      data={getTableData(stagesSelected)}
     />
   );
 }

--- a/components/maps/MapPoolDisplay.tsx
+++ b/components/maps/MapPoolDisplay.tsx
@@ -1,0 +1,95 @@
+import { RankedMode } from "@prisma/client";
+import { Box, Grid, useMediaQuery } from "@chakra-ui/react";
+import ModeImage from "../common/ModeImage";
+import SubText from "../common/SubText";
+import { t } from "@lingui/macro";
+import { FaCheck } from "react-icons/fa";
+import { CSSVariables } from "../../utils/CSSVariables";
+import NewTable from "../common/NewTable";
+
+export function MapPoolDisplay({
+  stagesSelected,
+}: {
+  stagesSelected: Record<string, RankedMode[]>;
+}) {
+  const [isMobile] = useMediaQuery("(max-width: 48em)");
+
+  return isMobile ? (
+    <Grid
+      mb={8}
+      templateColumns="repeat(4, 1fr)"
+      rowGap={4}
+      columnGap={4}
+      display="grid"
+    >
+      <Box textAlign="center">
+        <ModeImage mode="SZ" />
+      </Box>
+      <Box textAlign="center">
+        <ModeImage mode="TC" />
+      </Box>
+      <Box textAlign="center">
+        <ModeImage mode="RM" />
+      </Box>
+      <Box textAlign="center">
+        <ModeImage mode="CB" />
+      </Box>
+      <Box textAlign="center">
+        {Object.entries(stagesSelected).map(([stage, modes]) =>
+          modes.includes("SZ") ? (
+            <SubText key={stage}>{t({ id: stage })}</SubText>
+          ) : null
+        )}
+      </Box>
+      <Box textAlign="center">
+        {Object.entries(stagesSelected).map(([stage, modes]) =>
+          modes.includes("TC") ? (
+            <SubText key={stage}>{t({ id: stage })}</SubText>
+          ) : null
+        )}
+      </Box>
+      <Box textAlign="center">
+        {Object.entries(stagesSelected).map(([stage, modes]) =>
+          modes.includes("RM") ? (
+            <SubText key={stage}>{t({ id: stage })}</SubText>
+          ) : null
+        )}
+      </Box>
+      <Box textAlign="center">
+        {Object.entries(stagesSelected).map(([stage, modes]) =>
+          modes.includes("CB") ? (
+            <SubText key={stage}>{t({ id: stage })}</SubText>
+          ) : null
+        )}
+      </Box>
+    </Grid>
+  ) : (
+    <NewTable
+      size="sm"
+      headers={[
+        { name: t`Stage name`, dataKey: "stage" },
+        { name: t`Splat Zones`, dataKey: RankedMode.SZ },
+        { name: t`Tower Control`, dataKey: RankedMode.TC },
+        { name: t`Rainmaker`, dataKey: RankedMode.RM },
+        { name: t`Clam Blitz`, dataKey: RankedMode.CB },
+      ]}
+      data={Object.entries(stagesSelected).map(([stage, modes], index) =>
+        modes.length > 0
+          ? {
+              id: index,
+              stage: t({ id: stage }),
+              ...Object.values(RankedMode).reduce((map, mode) => {
+                map[mode] = modes.includes(mode) ? (
+                  <FaCheck
+                    color={CSSVariables.themeColor}
+                    style={{ margin: "auto" }}
+                  />
+                ) : null;
+                return map;
+              }, {} as { [mode in RankedMode]: JSX.Element | null }),
+            }
+          : null
+      )}
+    />
+  );
+}

--- a/pages/maps.tsx
+++ b/pages/maps.tsx
@@ -19,7 +19,6 @@ import {
   RadioGroup,
   Stack,
   Textarea,
-  useMediaQuery,
 } from "@chakra-ui/react";
 import { t, Trans } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
@@ -30,14 +29,10 @@ import SubText from "components/common/SubText";
 import { useMyRouter } from "hooks/useMyRouter";
 import { ChangeEvent, Fragment, useEffect, useState } from "react";
 import { FiCheck, FiFilter, FiRotateCw } from "react-icons/fi";
-import { BsTable } from "react-icons/bs";
-import { FaListUl, FaCheck } from "react-icons/fa";
 import { shuffleArray } from "utils/arrays";
 import { stages } from "utils/lists/stages";
 import MyHead from "../components/common/MyHead";
-import { Flex } from "@chakra-ui/layout";
-import NewTable from "../components/common/NewTable";
-import { CSSVariables } from "../utils/CSSVariables";
+import { MapPoolDisplay } from "../components/maps/MapPoolDisplay";
 
 const MapsGeneratorPage = () => {
   const router = useMyRouter();
@@ -59,8 +54,6 @@ const MapsGeneratorPage = () => {
   const [count, setCount] = useState(getInitialCount());
   const [editing, setEditing] = useState(false);
   const [copied, setCopied] = useState<null | "URL" | "LIST">(null);
-  const [displayType, setDisplayType] = useState<"TABLE" | "LIST">("LIST");
-  const [isMobile] = useMediaQuery("(max-width: 48em)");
 
   const [urlParams, setUrlParams] = useState<
     { key: string; value: string | string[] | undefined }[]
@@ -407,104 +400,7 @@ const MapsGeneratorPage = () => {
           </FormControl>
         </>
       ) : (
-        !isMobile && (
-          <>
-            <Flex flexDir="row-reverse" mb={4}>
-              <RadioGroup
-                value={displayType}
-                onChange={(value) => setDisplayType(value as "TABLE" | "LIST")}
-              >
-                <Stack direction="row" spacing={4} align="center">
-                  <Radio value="TABLE">
-                    <BsTable size={24} />
-                  </Radio>
-                  <Radio value="LIST">
-                    <FaListUl size={24} />
-                  </Radio>
-                </Stack>
-              </RadioGroup>
-            </Flex>
-            {displayType === "LIST" ? (
-              <Grid
-                mb={8}
-                templateColumns="repeat(4, 1fr)"
-                rowGap={4}
-                columnGap={4}
-                display="grid"
-              >
-                <Box textAlign="center">
-                  <ModeImage mode="SZ" />
-                </Box>
-                <Box textAlign="center">
-                  <ModeImage mode="TC" />
-                </Box>
-                <Box textAlign="center">
-                  <ModeImage mode="RM" />
-                </Box>
-                <Box textAlign="center">
-                  <ModeImage mode="CB" />
-                </Box>
-                <Box textAlign="center">
-                  {Object.entries(stagesSelected).map(([stage, modes]) =>
-                    modes.includes("SZ") ? (
-                      <SubText key={stage}>{t({ id: stage })}</SubText>
-                    ) : null
-                  )}
-                </Box>
-                <Box textAlign="center">
-                  {Object.entries(stagesSelected).map(([stage, modes]) =>
-                    modes.includes("TC") ? (
-                      <SubText key={stage}>{t({ id: stage })}</SubText>
-                    ) : null
-                  )}
-                </Box>
-                <Box textAlign="center">
-                  {Object.entries(stagesSelected).map(([stage, modes]) =>
-                    modes.includes("RM") ? (
-                      <SubText key={stage}>{t({ id: stage })}</SubText>
-                    ) : null
-                  )}
-                </Box>
-                <Box textAlign="center">
-                  {Object.entries(stagesSelected).map(([stage, modes]) =>
-                    modes.includes("CB") ? (
-                      <SubText key={stage}>{t({ id: stage })}</SubText>
-                    ) : null
-                  )}
-                </Box>
-              </Grid>
-            ) : (
-              <NewTable
-                size="sm"
-                headers={[
-                  { name: t`Stage name`, dataKey: "stage" },
-                  { name: t`Splat Zones`, dataKey: RankedMode.SZ },
-                  { name: t`Tower Control`, dataKey: RankedMode.TC },
-                  { name: t`Rainmaker`, dataKey: RankedMode.RM },
-                  { name: t`Clam Blitz`, dataKey: RankedMode.CB },
-                ]}
-                data={Object.entries(stagesSelected).map(
-                  ([stage, modes], index) =>
-                    modes.length > 0
-                      ? {
-                          id: index,
-                          stage: t({ id: stage }),
-                          ...Object.values(RankedMode).reduce((map, mode) => {
-                            map[mode] = modes.includes(mode) ? (
-                              <FaCheck
-                                color={CSSVariables.themeColor}
-                                style={{ margin: "auto" }}
-                              />
-                            ) : null;
-                            return map;
-                          }, {} as { [mode in RankedMode]: JSX.Element | null }),
-                        }
-                      : null
-                )}
-              />
-            )}
-          </>
-        )
+        <MapPoolDisplay stagesSelected={stagesSelected} />
       )}
       <Stack direction={["column", "row"]} spacing={4} mb={4} mt={4}>
         <Button

--- a/pages/maps.tsx
+++ b/pages/maps.tsx
@@ -18,7 +18,8 @@ import {
   Radio,
   RadioGroup,
   Stack,
-  Textarea, useMediaQuery,
+  Textarea,
+  useMediaQuery,
 } from "@chakra-ui/react";
 import { t, Trans } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
@@ -29,14 +30,14 @@ import SubText from "components/common/SubText";
 import { useMyRouter } from "hooks/useMyRouter";
 import { ChangeEvent, Fragment, useEffect, useState } from "react";
 import { FiCheck, FiFilter, FiRotateCw } from "react-icons/fi";
-import { BsTable } from 'react-icons/bs';
-import { FaListUl, FaCheck } from 'react-icons/fa';
+import { BsTable } from "react-icons/bs";
+import { FaListUl, FaCheck } from "react-icons/fa";
 import { shuffleArray } from "utils/arrays";
 import { stages } from "utils/lists/stages";
 import MyHead from "../components/common/MyHead";
-import { Flex } from '@chakra-ui/layout';
+import { Flex } from "@chakra-ui/layout";
 import NewTable from "../components/common/NewTable";
-import {CSSVariables} from "../utils/CSSVariables";
+import { CSSVariables } from "../utils/CSSVariables";
 
 const MapsGeneratorPage = () => {
   const router = useMyRouter();
@@ -405,90 +406,105 @@ const MapsGeneratorPage = () => {
             )}
           </FormControl>
         </>
-      ) : (!isMobile &&
-        <>
-          <Flex flexDir="row-reverse" mb={4}>
-            <RadioGroup value={displayType} onChange={(value) => setDisplayType(value as "TABLE" | "LIST")}>
-              <Stack direction="row" spacing={4} align="center">
-                <Radio value="TABLE">
-                  <BsTable size={24} />
-                </Radio>
-                <Radio value="LIST">
-                  <FaListUl size={24} />
-                </Radio>
-              </Stack>
-            </RadioGroup>
-          </Flex>
-          {displayType === "LIST" ? (
-            <Grid
-              mb={8}
-              templateColumns="repeat(4, 1fr)"
-              rowGap={4}
-              columnGap={4}
-              display="grid"
-            >
-              <Box textAlign="center">
-                <ModeImage mode="SZ" />
-              </Box>
-              <Box textAlign="center">
-                <ModeImage mode="TC" />
-              </Box>
-              <Box textAlign="center">
-                <ModeImage mode="RM" />
-              </Box>
-              <Box textAlign="center">
-                <ModeImage mode="CB" />
-              </Box>
-              <Box textAlign="center">
-                {Object.entries(stagesSelected).map(([stage, modes]) =>
-                  modes.includes("SZ") ? (
-                    <SubText key={stage}>{t({id: stage})}</SubText>
-                  ) : null
+      ) : (
+        !isMobile && (
+          <>
+            <Flex flexDir="row-reverse" mb={4}>
+              <RadioGroup
+                value={displayType}
+                onChange={(value) => setDisplayType(value as "TABLE" | "LIST")}
+              >
+                <Stack direction="row" spacing={4} align="center">
+                  <Radio value="TABLE">
+                    <BsTable size={24} />
+                  </Radio>
+                  <Radio value="LIST">
+                    <FaListUl size={24} />
+                  </Radio>
+                </Stack>
+              </RadioGroup>
+            </Flex>
+            {displayType === "LIST" ? (
+              <Grid
+                mb={8}
+                templateColumns="repeat(4, 1fr)"
+                rowGap={4}
+                columnGap={4}
+                display="grid"
+              >
+                <Box textAlign="center">
+                  <ModeImage mode="SZ" />
+                </Box>
+                <Box textAlign="center">
+                  <ModeImage mode="TC" />
+                </Box>
+                <Box textAlign="center">
+                  <ModeImage mode="RM" />
+                </Box>
+                <Box textAlign="center">
+                  <ModeImage mode="CB" />
+                </Box>
+                <Box textAlign="center">
+                  {Object.entries(stagesSelected).map(([stage, modes]) =>
+                    modes.includes("SZ") ? (
+                      <SubText key={stage}>{t({ id: stage })}</SubText>
+                    ) : null
+                  )}
+                </Box>
+                <Box textAlign="center">
+                  {Object.entries(stagesSelected).map(([stage, modes]) =>
+                    modes.includes("TC") ? (
+                      <SubText key={stage}>{t({ id: stage })}</SubText>
+                    ) : null
+                  )}
+                </Box>
+                <Box textAlign="center">
+                  {Object.entries(stagesSelected).map(([stage, modes]) =>
+                    modes.includes("RM") ? (
+                      <SubText key={stage}>{t({ id: stage })}</SubText>
+                    ) : null
+                  )}
+                </Box>
+                <Box textAlign="center">
+                  {Object.entries(stagesSelected).map(([stage, modes]) =>
+                    modes.includes("CB") ? (
+                      <SubText key={stage}>{t({ id: stage })}</SubText>
+                    ) : null
+                  )}
+                </Box>
+              </Grid>
+            ) : (
+              <NewTable
+                size="sm"
+                headers={[
+                  { name: t`Stage name`, dataKey: "stage" },
+                  { name: t`Splat Zones`, dataKey: RankedMode.SZ },
+                  { name: t`Tower Control`, dataKey: RankedMode.TC },
+                  { name: t`Rainmaker`, dataKey: RankedMode.RM },
+                  { name: t`Clam Blitz`, dataKey: RankedMode.CB },
+                ]}
+                data={Object.entries(stagesSelected).map(
+                  ([stage, modes], index) =>
+                    modes.length > 0
+                      ? {
+                          id: index,
+                          stage: t({ id: stage }),
+                          ...Object.values(RankedMode).reduce((map, mode) => {
+                            map[mode] = modes.includes(mode) ? (
+                              <FaCheck
+                                color={CSSVariables.themeColor}
+                                style={{ margin: "auto" }}
+                              />
+                            ) : null;
+                            return map;
+                          }, {} as { [mode in RankedMode]: JSX.Element | null }),
+                        }
+                      : null
                 )}
-              </Box>
-              <Box textAlign="center">
-                {Object.entries(stagesSelected).map(([stage, modes]) =>
-                  modes.includes("TC") ? (
-                    <SubText key={stage}>{t({id: stage})}</SubText>
-                  ) : null
-                )}
-              </Box>
-              <Box textAlign="center">
-                {Object.entries(stagesSelected).map(([stage, modes]) =>
-                  modes.includes("RM") ? (
-                    <SubText key={stage}>{t({id: stage})}</SubText>
-                  ) : null
-                )}
-              </Box>
-              <Box textAlign="center">
-                {Object.entries(stagesSelected).map(([stage, modes]) =>
-                  modes.includes("CB") ? (
-                    <SubText key={stage}>{t({id: stage})}</SubText>
-                  ) : null
-                )}
-              </Box>
-            </Grid>
-          ) : (
-            <NewTable
-              size="sm"
-              headers={[
-                { name: t`Stage name`, dataKey: "stage" },
-                { name: t`Splat Zones`, dataKey: RankedMode.SZ },
-                { name: t`Tower Control`, dataKey: RankedMode.TC },
-                { name: t`Rainmaker`, dataKey: RankedMode.RM },
-                { name: t`Clam Blitz`, dataKey: RankedMode.CB }
-              ]}
-              data={Object.entries(stagesSelected).map(([stage, modes], index) => (modes.length > 0 ? {
-                id: index,
-                stage: t({id: stage}),
-                ...(Object.values(RankedMode).reduce((map, mode) => {
-                  map[mode] = (modes.includes(mode) ? <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} /> : null);
-                  return map;
-                }, ({} as {[mode in RankedMode]: JSX.Element | null}))),
-              } : null))}
-            />
-          )}
-        </>
+              />
+            )}
+          </>
+        )
       )}
       <Stack direction={["column", "row"]} spacing={4} mb={4} mt={4}>
         <Button

--- a/pages/maps.tsx
+++ b/pages/maps.tsx
@@ -442,28 +442,28 @@ const MapsGeneratorPage = () => {
               <Box textAlign="center">
                 {Object.entries(stagesSelected).map(([stage, modes]) =>
                   modes.includes("SZ") ? (
-                    <SubText key={stage}>{stage}</SubText>
+                    <SubText key={stage}>{t({id: stage})}</SubText>
                   ) : null
                 )}
               </Box>
               <Box textAlign="center">
                 {Object.entries(stagesSelected).map(([stage, modes]) =>
                   modes.includes("TC") ? (
-                    <SubText key={stage}>{stage}</SubText>
+                    <SubText key={stage}>{t({id: stage})}</SubText>
                   ) : null
                 )}
               </Box>
               <Box textAlign="center">
                 {Object.entries(stagesSelected).map(([stage, modes]) =>
                   modes.includes("RM") ? (
-                    <SubText key={stage}>{stage}</SubText>
+                    <SubText key={stage}>{t({id: stage})}</SubText>
                   ) : null
                 )}
               </Box>
               <Box textAlign="center">
                 {Object.entries(stagesSelected).map(([stage, modes]) =>
                   modes.includes("CB") ? (
-                    <SubText key={stage}>{stage}</SubText>
+                    <SubText key={stage}>{t({id: stage})}</SubText>
                   ) : null
                 )}
               </Box>
@@ -472,19 +472,19 @@ const MapsGeneratorPage = () => {
             <NewTable
               size="sm"
               headers={[
-                { name: "Stage name", dataKey: "stage" },
-                { name: "Splat Zones", dataKey: "SZ" },
-                { name: "Tower Control", dataKey: "TC" },
-                { name: "Rainmaker", dataKey: "RM" },
-                { name: "Clam Blitz", dataKey: "CB" }
+                { name: t`Stage name`, dataKey: "stage" },
+                { name: t`Splat Zones`, dataKey: RankedMode.SZ },
+                { name: t`Tower Control`, dataKey: RankedMode.TC },
+                { name: t`Rainmaker`, dataKey: RankedMode.RM },
+                { name: t`Clam Blitz`, dataKey: RankedMode.CB }
               ]}
               data={Object.entries(stagesSelected).map(([stage, modes], index) => (modes.length > 0 ? {
                 id: index,
-                stage,
-                SZ: modes.includes("SZ") ? <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} /> : null,
-                TC: modes.includes("TC") ? <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} /> : null,
-                RM: modes.includes("RM") ? <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} /> : null,
-                CB: modes.includes("CB") ? <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} /> : null
+                stage: t({id: stage}),
+                ...(Object.values(RankedMode).reduce((map, mode) => {
+                  map[mode] = (modes.includes(mode) ? <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} /> : null);
+                  return map;
+                }, ({} as {[mode in RankedMode]: JSX.Element | null}))),
               } : null))}
             />
           )}

--- a/pages/maps.tsx
+++ b/pages/maps.tsx
@@ -18,7 +18,7 @@ import {
   Radio,
   RadioGroup,
   Stack,
-  Textarea,
+  Textarea, useMediaQuery,
 } from "@chakra-ui/react";
 import { t, Trans } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
@@ -29,9 +29,14 @@ import SubText from "components/common/SubText";
 import { useMyRouter } from "hooks/useMyRouter";
 import { ChangeEvent, Fragment, useEffect, useState } from "react";
 import { FiCheck, FiFilter, FiRotateCw } from "react-icons/fi";
+import { BsTable } from 'react-icons/bs';
+import { FaListUl, FaCheck } from 'react-icons/fa';
 import { shuffleArray } from "utils/arrays";
 import { stages } from "utils/lists/stages";
 import MyHead from "../components/common/MyHead";
+import { Flex } from '@chakra-ui/layout';
+import NewTable from "../components/common/NewTable";
+import {CSSVariables} from "../utils/CSSVariables";
 
 const MapsGeneratorPage = () => {
   const router = useMyRouter();
@@ -53,6 +58,8 @@ const MapsGeneratorPage = () => {
   const [count, setCount] = useState(getInitialCount());
   const [editing, setEditing] = useState(false);
   const [copied, setCopied] = useState<null | "URL" | "LIST">(null);
+  const [displayType, setDisplayType] = useState<"TABLE" | "LIST">("LIST");
+  const [isMobile] = useMediaQuery("(max-width: 48em)");
 
   const [urlParams, setUrlParams] = useState<
     { key: string; value: string | string[] | undefined }[]
@@ -398,57 +405,92 @@ const MapsGeneratorPage = () => {
             )}
           </FormControl>
         </>
-      ) : (
-        <Grid
-          mb={8}
-          templateColumns="repeat(4, 1fr)"
-          rowGap={4}
-          columnGap={4}
-          display={["none", null, "grid"]}
-        >
-          <Box textAlign="center">
-            <ModeImage mode="SZ" />
-          </Box>
-          <Box textAlign="center">
-            <ModeImage mode="TC" />
-          </Box>
-          <Box textAlign="center">
-            <ModeImage mode="RM" />
-          </Box>
-          <Box textAlign="center">
-            <ModeImage mode="CB" />
-          </Box>
-          <Box textAlign="center">
-            {Object.entries(stagesSelected).map(([stage, modes]) =>
-              modes.includes("SZ") ? (
-                <SubText key={stage}>{stage}</SubText>
-              ) : null
-            )}
-          </Box>
-          <Box textAlign="center">
-            {Object.entries(stagesSelected).map(([stage, modes]) =>
-              modes.includes("TC") ? (
-                <SubText key={stage}>{stage}</SubText>
-              ) : null
-            )}
-          </Box>
-          <Box textAlign="center">
-            {Object.entries(stagesSelected).map(([stage, modes]) =>
-              modes.includes("RM") ? (
-                <SubText key={stage}>{stage}</SubText>
-              ) : null
-            )}
-          </Box>
-          <Box textAlign="center">
-            {Object.entries(stagesSelected).map(([stage, modes]) =>
-              modes.includes("CB") ? (
-                <SubText key={stage}>{stage}</SubText>
-              ) : null
-            )}
-          </Box>
-        </Grid>
+      ) : (!isMobile &&
+        <>
+          <Flex flexDir="row-reverse" mb={4}>
+            <RadioGroup value={displayType} onChange={(value) => setDisplayType(value as "TABLE" | "LIST")}>
+              <Stack direction="row" spacing={4} align="center">
+                <Radio value="TABLE">
+                  <BsTable size={24} />
+                </Radio>
+                <Radio value="LIST">
+                  <FaListUl size={24} />
+                </Radio>
+              </Stack>
+            </RadioGroup>
+          </Flex>
+          {displayType === "LIST" ? (
+            <Grid
+              mb={8}
+              templateColumns="repeat(4, 1fr)"
+              rowGap={4}
+              columnGap={4}
+              display="grid"
+            >
+              <Box textAlign="center">
+                <ModeImage mode="SZ" />
+              </Box>
+              <Box textAlign="center">
+                <ModeImage mode="TC" />
+              </Box>
+              <Box textAlign="center">
+                <ModeImage mode="RM" />
+              </Box>
+              <Box textAlign="center">
+                <ModeImage mode="CB" />
+              </Box>
+              <Box textAlign="center">
+                {Object.entries(stagesSelected).map(([stage, modes]) =>
+                  modes.includes("SZ") ? (
+                    <SubText key={stage}>{stage}</SubText>
+                  ) : null
+                )}
+              </Box>
+              <Box textAlign="center">
+                {Object.entries(stagesSelected).map(([stage, modes]) =>
+                  modes.includes("TC") ? (
+                    <SubText key={stage}>{stage}</SubText>
+                  ) : null
+                )}
+              </Box>
+              <Box textAlign="center">
+                {Object.entries(stagesSelected).map(([stage, modes]) =>
+                  modes.includes("RM") ? (
+                    <SubText key={stage}>{stage}</SubText>
+                  ) : null
+                )}
+              </Box>
+              <Box textAlign="center">
+                {Object.entries(stagesSelected).map(([stage, modes]) =>
+                  modes.includes("CB") ? (
+                    <SubText key={stage}>{stage}</SubText>
+                  ) : null
+                )}
+              </Box>
+            </Grid>
+          ) : (
+            <NewTable
+              size="sm"
+              headers={[
+                { name: "Stage name", dataKey: "stage" },
+                { name: "Splat Zones", dataKey: "SZ" },
+                { name: "Tower Control", dataKey: "TC" },
+                { name: "Rainmaker", dataKey: "RM" },
+                { name: "Clam Blitz", dataKey: "CB" }
+              ]}
+              data={Object.entries(stagesSelected).map(([stage, modes], index) => (modes.length > 0 ? {
+                id: index,
+                stage,
+                SZ: modes.includes("SZ") ? <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} /> : null,
+                TC: modes.includes("TC") ? <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} /> : null,
+                RM: modes.includes("RM") ? <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} /> : null,
+                CB: modes.includes("CB") ? <FaCheck color={CSSVariables.themeColor} style={{ margin: "auto" }} /> : null
+              } : null))}
+            />
+          )}
+        </>
       )}
-      <Stack direction={["column", "row"]} spacing={4} mb={4}>
+      <Stack direction={["column", "row"]} spacing={4} mb={4} mt={4}>
         <Button
           leftIcon={<FiRotateCw />}
           onClick={() => {


### PR DESCRIPTION
 This PR adds an alternate method of displaying the map pool.

### Why?
I was tasked with creating a [map pool graphic](https://cdn.discordapp.com/attachments/722960400831873105/862796200897150976/lowinkmaps-jul21.png) based off a screenshot from the s.ink map list generator, which I found mildly annoying due to the way the map pool is displayed.