### PR TITLE
#574 handling UNKNOWN ability and allow builds to use Not Set

### DIFF
--- a/components/analyzer/EditableBuilds.tsx
+++ b/components/analyzer/EditableBuilds.tsx
@@ -78,6 +78,10 @@ const EditableBuilds: React.FC<EditableBuildsProps> = ({
     : "SSU";
 
   const isBuildEmpty = (build: Omit<ViewSlotsAbilities, "weapon">) => {
+    // If build is incomplete or malformed, return true.
+    if (build.headAbilities.length !== 4 || build.clothingAbilities.length !== 4 || build.shoesAbilities.length !== 4) {
+      return true
+    }
     return [
       ...build.headAbilities,
       ...build.clothingAbilities,

--- a/components/u/AbilitiesSelector.tsx
+++ b/components/u/AbilitiesSelector.tsx
@@ -111,7 +111,7 @@ const AbilitiesSelector: React.FC<Props> = ({ abilities, setAbilities }) => {
       <Divider maxWidth={64} my={4} mx="auto" />
       <Flex flexWrap="wrap" justifyContent="center" maxW="350px" mx="auto">
         {allAbilities
-          .filter((ability) => ability.type === "STACKABLE")
+          .filter((ability) => ability.type === "STACKABLE" && ability.code !== "UNKNOWN")
           .map((ability) => (
             <Box
               m="0.3em"

--- a/components/u/BuildModal.tsx
+++ b/components/u/BuildModal.tsx
@@ -196,8 +196,8 @@ const BuildModal: React.FC<Props> = ({ onClose, build, weaponFromQuery }) => {
               {/* yeah....... didn't find an easier way to do this with the library so here we are */}
               <FormControl
                 isInvalid={
-                  !!errors.headAbilities ||
-                  !!errors.clothingAbilities ||
+                  !!errors.headAbilities &&
+                  !!errors.clothingAbilities &&
                   !!errors.shoesAbilities
                 }
               >

--- a/pages/analyzer.tsx
+++ b/pages/analyzer.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, Button, FormLabel, Switch, Wrap } from "@chakra-ui/react";
+import { Badge, Box, Button, FormLabel, Link, Switch, Wrap } from "@chakra-ui/react";
 import { t, Trans } from "@lingui/macro";
 import BuildStats from "components/analyzer/BuildStats";
 import EditableBuilds from "components/analyzer/EditableBuilds";
@@ -6,7 +6,8 @@ import { ViewSlotsAbilities } from "components/builds/ViewSlots";
 import WeaponSelector from "components/common/WeaponSelector";
 import useAbilityEffects from "hooks/useAbilityEffects";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
+import { FaRedo } from "react-icons/fa";
 import { FiSettings } from "react-icons/fi";
 import { CSSVariables } from "utils/CSSVariables";
 import { isAbilityArray } from "utils/lists/abilities";
@@ -149,6 +150,22 @@ const BuildAnalyzerPage = () => {
                   {t`Start charts Y axis from zero`}
                 </FormLabel>
               </Box>
+              <Link
+              href={encodeURI(
+                `/analyzer?weapon=${weapon}&head=${build.headAbilities}&clothing=${build.clothingAbilities}&shoes=${build.shoesAbilities}`
+              )}
+              >
+                <a>
+                  <Button
+                    leftIcon={<FaRedo />}
+                    my="1rem"
+                    size="sm"
+                    variant="outline"
+                  >
+                    {t`Show in Build Analyzer`}
+                  </Button>
+                </a>
+              </Link>
             </Box>
           )}
           <Box m="1rem" w={["95%", null, "30rem"]}>

--- a/utils/lists/abilities.ts
+++ b/utils/lists/abilities.ts
@@ -42,6 +42,7 @@ export const abilities = [
   { code: "SJ", name: t`Stealth Jump`, type: "SHOES" },
   { code: "OS", name: t`Object Shredder`, type: "SHOES" },
   { code: "DR", name: t`Drop Roller`, type: "SHOES" },
+  { code: "UNKNOWN", name: t`Not set`, type: "STACKABLE" },
 ] as const;
 
 export const isMainAbility = (ability: any) =>

--- a/utils/lists/abilityMarkdownCodes.ts
+++ b/utils/lists/abilityMarkdownCodes.ts
@@ -25,4 +25,5 @@ export const abilityMarkdownCodes = {
   sj: "SJ",
   os: "OS",
   dr: "DR",
+  unknown: "UNKNOWN",
 } as const;

--- a/utils/validators/common.ts
+++ b/utils/validators/common.ts
@@ -29,4 +29,5 @@ export const abilityEnum = z.enum([
   "SJ",
   "OS",
   "DR",
+  "UNKNOWN"
 ]);


### PR DESCRIPTION
Addresses #574. 

Also includes a "refresh" button in the analyzer settings to reload the page with the entered abilities, though a neater solution would be to update the URL as changes are made.

Further testing might be needed as I do not have Postgres installed plus some NPM issues.