### PR TITLE
Other default value + empty onChange

### DIFF
--- a/app/routes/u.$identifier/builds/new.tsx
+++ b/app/routes/u.$identifier/builds/new.tsx
@@ -379,8 +379,9 @@ function Abilities() {
         value={
           abilities.flat().every((a) => a !== "UNKNOWN")
             ? JSON.stringify(abilities)
-            : undefined
+            : []
         }
+        onChange={() => {}}
         required
       />
       <AbilitiesSelector

--- a/app/routes/u.$identifier/builds/new.tsx
+++ b/app/routes/u.$identifier/builds/new.tsx
@@ -381,7 +381,9 @@ function Abilities() {
             ? JSON.stringify(abilities)
             : []
         }
-        onChange={() => {}}
+        // empty onChange is because otherwise it will give a React error in console
+        // readOnly can't be set as then validation is not active
+        onChange={() => null}
         required
       />
       <AbilitiesSelector


### PR DESCRIPTION
#946 
Looks like empty array is enough to be controlled after init and be empty so required trigger alert for input.

Empty onChange is because otherwise it will give another error in console (and readonly doensn't work in this case). Maybe it could be done in a better way.
![no onchange](https://user-images.githubusercontent.com/12849336/190601783-30f2db01-6b62-407b-9d37-5e696b16da6f.png)
