### PR TITLE
Adding of Missing Danish translations.

### DIFF
--- a/public/locales/da/common.json
+++ b/public/locales/da/common.json
@@ -6,6 +6,7 @@
   "pages.calendar": "Kalender",
   "pages.faq": "FAQ",
   "pages.builds": "Udrustningssæt",
+  "pages.analyzer": "Udrustningsanalysator",
 
   "header.profile": "Profil",
   "header.logout": "Log ud",

--- a/public/locales/da/contributions.json
+++ b/public/locales/da/contributions.json
@@ -3,6 +3,6 @@
   "code": "Mange har bidraget til koden",
   "lean": "Hjalp med at fremvise Splatoons indre og skabte Lanista-botten",
   "borzoic": "lavede mærker, ikoner and forsidekunst",
-  "uberu": "Tegnede mini-Judd mens han holder et hjerte-emoji"
+  "uberu": "Tegnede mini-Judd mens han holder et hjerte-emoji",
   "translation": "Oversættelse"
 }

--- a/public/locales/da/contributions.json
+++ b/public/locales/da/contributions.json
@@ -4,4 +4,5 @@
   "lean": "Hjalp med at fremvise Splatoons indre og skabte Lanista-botten",
   "borzoic": "lavede mærker, ikoner and forsidekunst",
   "uberu": "Tegnede mini-Judd mens han holder et hjerte-emoji"
+  "translation": "Oversættelse"
 }

--- a/public/locales/da/front.json
+++ b/public/locales/da/front.json
@@ -4,6 +4,7 @@
   "moreFeatures": "Flere funktioner",
   "plus.description": "Se plus-serverens valghistorik med mere",
   "badges.description": "Liste af alle de premiemærker til din profil, som du kan gøre dig fortjent til",
+  "analyzer.description": "Undersøg hvordan dine udrustinger giver dig af fordele i kamp",
   "recentWinners": "Se de seneste vindere",
   "upcomingEvents": "Kommende begivenheder",
   "articleBy": "Af {{author}}"

--- a/translation-progress.md
+++ b/translation-progress.md
@@ -18,42 +18,21 @@
 
 **44/44**
 
-### 🟡 common.json
+### 🟢 common.json
 
-**35/36**
+**36/36**
 
-<details>
-<summary>Missing</summary>
+### 🟢 contributions.json
 
-- pages.analyzer
-
-</details>
-
-### 🟡 contributions.json
-
-**5/6**
-
-<details>
-<summary>Missing</summary>
-
-- translation
-
-</details>
+**6/6**
 
 ### 🟢 faq.json
 
 **6/6**
 
-### 🟡 front.json
+### 🟢 front.json
 
-**8/9**
-
-<details>
-<summary>Missing</summary>
-
-- analyzer.description
-
-</details>
+**9/9**
 
 ### 🟢 user.json
 


### PR DESCRIPTION
Added Translations for the missing lines in the following json.files.
The lines are placed, so the correspond with the English location files.


**common.json**

1. pages.analyzer

**contributions.json**

1. translation


**front.json**

1. analyzer.description