### PR TITLE
Make `<Ability/>` support keyboard navigation

### DIFF
--- a/app/components/Ability.tsx
+++ b/app/components/Ability.tsx
@@ -20,7 +20,7 @@ export function Ability({
   const sizeNumber = sizeMap[size];
 
   return (
-    <div
+    <button
       className="build__ability"
       style={
         {
@@ -31,6 +31,6 @@ export function Ability({
       data-cy={`${ability}-ability`}
     >
       <Image alt="" path={abilityImageUrl(ability)} />
-    </div>
+    </button>
   );
 }

--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -792,6 +792,7 @@ dialog::backdrop {
   border-radius: 50%;
   box-shadow: 0 0 0 1px var(--bg-ability);
   user-select: none;
+  padding: 0;
 }
 
 .build__bottom-row {

--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -784,6 +784,7 @@ dialog::backdrop {
 .build__ability {
   width: var(--ability-size);
   height: var(--ability-size);
+  padding: 0;
   border: 2px solid var(--theme-transparent);
   border-right: 0;
   border-bottom: 0;
@@ -792,7 +793,6 @@ dialog::backdrop {
   border-radius: 50%;
   box-shadow: 0 0 0 1px var(--bg-ability);
   user-select: none;
-  padding: 0;
 }
 
 .build__bottom-row {


### PR DESCRIPTION
`<Ability/>` can now be tabbed through, and it now shares the same focus outline, hover, and mousedown styles with `<AbilitiesSelector/>`. This includes the `cursor: pointer` style that makes it more obvious that this component is clickable like other buttons.

Fixes #894.

Before:

https://user-images.githubusercontent.com/3038600/192218613-2754506e-520b-4629-b35c-5440afac3b0e.mov

After:

https://user-images.githubusercontent.com/3038600/192218785-8e40da09-d512-47fe-9341-bcee18c213be.mov


