### PR TITLE
Add ability to drag abilities into slots

### DIFF
--- a/app/components/AbilitiesSelector.tsx
+++ b/app/components/AbilitiesSelector.tsx
@@ -1,3 +1,5 @@
+import clsx from "clsx";
+import React from "react";
 import invariant from "tiny-invariant";
 import { abilities } from "~/modules/in-game-lists";
 import type { BuildAbilitiesTupleWithUnknown } from "~/modules/in-game-lists/types";
@@ -40,6 +42,38 @@ export function AbilitiesSelector({
     onChange(addAbility({ oldAbilities: selectedAbilities, ability }));
   };
 
+  const [draggingAbility, setDraggingAbility] = React.useState<
+    typeof abilities[number] | undefined
+  >();
+
+  const onDragStart =
+    (ability: typeof abilities[number]) => (event: React.DragEvent) => {
+      setDraggingAbility(ability);
+      event.dataTransfer.setData("text/plain", JSON.stringify(ability));
+    };
+
+  const onDragEnd = () => {
+    setDraggingAbility(undefined);
+  };
+
+  const onDrop =
+    (atRowIndex: number, atAbilityIndex: number) =>
+    (event: React.DragEvent) => {
+      event.preventDefault();
+      const ability = JSON.parse(
+        event.dataTransfer.getData("text/plain")
+      ) as typeof abilities[number];
+
+      onChange(
+        addAbility({
+          oldAbilities: selectedAbilities,
+          ability,
+          atRowIndex,
+          atAbilityIndex,
+        })
+      );
+    };
+
   return (
     <div className="ability-selector__container">
       <div className="ability-selector__slots">
@@ -50,6 +84,13 @@ export function AbilitiesSelector({
               ability={ability}
               size={abilityI === 0 ? "MAIN" : "SUB"}
               onClick={() => onSlotClick({ rowI, abilityI })}
+              dragStarted={!!draggingAbility}
+              dropAllowed={canPlaceAbilityAtSlot(
+                rowI,
+                abilityI,
+                draggingAbility
+              )}
+              onDrop={onDrop(rowI, abilityI)}
             />
           ))
         )}
@@ -58,10 +99,15 @@ export function AbilitiesSelector({
         {abilities.map((ability) => (
           <button
             key={ability.name}
-            className="ability-selector__ability-button"
+            className={clsx("ability-selector__ability-button", {
+              "is-dragging": ability.name === draggingAbility?.name,
+            })}
             type="button"
             onClick={() => onButtonClick(ability)}
             data-cy={`${ability.name}-ability-button`}
+            draggable="true"
+            onDragStart={onDragStart(ability)}
+            onDragEnd={onDragEnd}
           >
             <Image
               alt=""
@@ -76,45 +122,81 @@ export function AbilitiesSelector({
   );
 }
 
+const canPlaceAbilityAtSlot = (
+  rowIndex: number,
+  abilityIndex: number,
+  ability?: typeof abilities[number]
+) => {
+  if (!ability) {
+    return false;
+  }
+
+  const legalGearTypeForMain =
+    rowIndex === 0
+      ? "HEAD_MAIN_ONLY"
+      : rowIndex === 1
+      ? "CLOTHES_MAIN_ONLY"
+      : "SHOES_MAIN_ONLY";
+
+  const isMainSlot = abilityIndex === 0;
+
+  if (
+    !["STACKABLE", legalGearTypeForMain].includes(ability.type) &&
+    isMainSlot
+  ) {
+    // Can't put this type of gear in main slot
+    return false;
+  }
+
+  if (!isMainSlot && ability.type !== "STACKABLE") {
+    // Can't put main slot only gear to sub slots
+    return false;
+  }
+  return true;
+};
+
 function addAbility({
   oldAbilities,
   ability,
+  atRowIndex,
+  atAbilityIndex,
 }: {
   oldAbilities: BuildAbilitiesTupleWithUnknown;
   ability: typeof abilities[number];
+  atRowIndex?: number;
+  atAbilityIndex?: number;
 }): BuildAbilitiesTupleWithUnknown {
   const abilitiesClone = JSON.parse(
     JSON.stringify(oldAbilities)
   ) as BuildAbilitiesTupleWithUnknown;
 
-  for (const [i, row] of abilitiesClone.entries()) {
-    const legalGearTypeForMain =
-      i === 0
-        ? "HEAD_MAIN_ONLY"
-        : i === 1
-        ? "CLOTHES_MAIN_ONLY"
-        : "SHOES_MAIN_ONLY";
+  if (atRowIndex !== undefined && atAbilityIndex !== undefined) {
+    // Attempt to place the ability at a specific slot since we
+    // were given an atRowIndex and atAbilityIndex
+    if (canPlaceAbilityAtSlot(atRowIndex, atAbilityIndex, ability)) {
+      // Assign this ability to the slot
+      abilitiesClone[atRowIndex]![atAbilityIndex] = ability.name;
+    }
+  } else {
+    // Loop through all slots and attempt to place this ability
+    // in the first empty one
+    for (const [rowIndex, row] of abilitiesClone.entries()) {
+      for (const [abilityIndex, oldAbility] of row.entries()) {
+        if (oldAbility !== "UNKNOWN") {
+          // Skip any filled slots in this loop until we arrive at an empty one.
+          continue;
+        }
 
-    for (const [j, oldAbility] of row.entries()) {
-      const isMainSlot = j === 0;
+        if (!canPlaceAbilityAtSlot(rowIndex, abilityIndex, ability)) {
+          // This ability isn't valid for this slot
+          continue;
+        }
 
-      // slot is not empty
-      if (oldAbility !== "UNKNOWN") continue;
+        // Assign this ability to the slot
+        abilitiesClone[rowIndex]![abilityIndex] = ability.name;
 
-      // can't put this type of gear in main slot
-      if (
-        !["STACKABLE", legalGearTypeForMain].includes(ability.type) &&
-        isMainSlot
-      ) {
-        continue;
+        return abilitiesClone;
       }
-
-      // can't put main slot only gear to sub slots
-      if (!isMainSlot && ability.type !== "STACKABLE") continue;
-
-      abilitiesClone[i]![j] = ability.name;
-
-      return abilitiesClone;
     }
   }
 

--- a/app/components/Ability.tsx
+++ b/app/components/Ability.tsx
@@ -13,15 +13,15 @@ const sizeMap = {
 export function Ability({
   ability,
   size,
-  dragStarted,
-  dropAllowed,
+  dragStarted = false,
+  dropAllowed = false,
   onClick,
   onDrop,
 }: {
   ability: AbilityWithUnknown;
   size: keyof typeof sizeMap;
-  dragStarted: boolean;
-  dropAllowed: boolean;
+  dragStarted?: boolean;
+  dropAllowed?: boolean;
   onClick?: () => void;
   onDrop?: (event: React.DragEvent) => void;
 }) {

--- a/app/components/Ability.tsx
+++ b/app/components/Ability.tsx
@@ -1,3 +1,5 @@
+import clsx from "clsx";
+import React from "react";
 import type { AbilityWithUnknown } from "~/modules/in-game-lists/types";
 import { abilityImageUrl } from "~/utils/urls";
 import { Image } from "./Image";
@@ -11,17 +13,38 @@ const sizeMap = {
 export function Ability({
   ability,
   size,
+  dragStarted,
+  dropAllowed,
   onClick,
+  onDrop,
 }: {
   ability: AbilityWithUnknown;
   size: keyof typeof sizeMap;
+  dragStarted: boolean;
+  dropAllowed: boolean;
   onClick?: () => void;
+  onDrop?: (event: React.DragEvent) => void;
 }) {
   const sizeNumber = sizeMap[size];
 
+  const [isDragTarget, setIsDragTarget] = React.useState(false);
+
+  const onDragOver = (event: React.DragEvent) => {
+    event.preventDefault();
+    setIsDragTarget(true);
+  };
+
+  const onDragLeave = () => {
+    setIsDragTarget(false);
+  };
+
   return (
     <button
-      className="build__ability"
+      className={clsx("build__ability", {
+        "is-drag-target": isDragTarget,
+        "drag-started": dragStarted,
+        "drop-allowed": dropAllowed,
+      })}
       style={
         {
           "--ability-size": `${sizeNumber}px`,
@@ -29,6 +52,12 @@ export function Ability({
       }
       onClick={onClick}
       data-cy={`${ability}-ability`}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={(event) => {
+        setIsDragTarget(false);
+        onDrop?.(event);
+      }}
     >
       <Image alt="" path={abilityImageUrl(ability)} />
     </button>

--- a/app/components/Image.tsx
+++ b/app/components/Image.tsx
@@ -32,6 +32,7 @@ export function Image({
         width={width}
         height={height}
         style={style}
+        draggable="false"
       />
     </picture>
   );

--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -792,7 +792,20 @@ dialog::backdrop {
   background-size: 100%;
   border-radius: 50%;
   box-shadow: 0 0 0 1px var(--bg-ability);
+  transform: scale(1);
+  transition: all 0.1s ease;
   user-select: none;
+}
+
+.build__ability.is-drag-target {
+  background: var(--abilities-button-bg);
+  transform: scale(1.15);
+}
+
+.build__ability.drag-started:not(.drop-allowed) {
+  filter: grayscale(1);
+  opacity: 0.3;
+  pointer-events: none;
 }
 
 .build__bottom-row {
@@ -840,4 +853,8 @@ dialog::backdrop {
   border-color: var(--abilities-button-bg);
   background-color: var(--abilities-button-bg);
   border-radius: 50%;
+}
+
+.ability-selector__ability-button.is-dragging {
+  box-shadow: 0 0 100px inset rgb(255 255 255 / 25%);
 }


### PR DESCRIPTION
- Do not allow dragging an ability onto a slot that cannot accept that ability.
- When dragging, dim slots that are not a valid target for the ability currently being dragged.
- Do not make any changes to the existing click behavior to assign abilities.

This addresses #82 but I don't know if this closes it: this PR does not implement the bonus idea of holding shift to duplicate abilities across slots. That should be possible, but we would likely have to use a drag/drop library and not necessarily the native drag and drop API (which is what this PR relies on). I think this might add a bit of complexity.

Possible area for further improvement: add the ability to drag a placed ability (one already assigned to a slot) from one slot to another. I can make an issue if this is something you would like.

This does currently only works on desktop. Mobile continues to behave the same as it previously did. (This might be a limitation of using the drag and drop API but I would need to investigate further).

## Demo

Both the build analyzer and the profile builds pages now support drag and drop (blue circles are from the screen recording program and not the webpage):

https://user-images.githubusercontent.com/3038600/193397650-316e498f-5ed5-41b6-bd9a-0f49deb5eb24.mp4
