### PR TITLE
Fix issue where abilities appeared clickable when they were not

### DIFF
--- a/app/components/Ability.tsx
+++ b/app/components/Ability.tsx
@@ -13,6 +13,7 @@ const sizeMap = {
 export function Ability({
   ability,
   size,
+  readonly = false,
   dragStarted = false,
   dropAllowed = false,
   onClick,
@@ -20,6 +21,7 @@ export function Ability({
 }: {
   ability: AbilityWithUnknown;
   size: keyof typeof sizeMap;
+  readonly?: boolean;
   dragStarted?: boolean;
   dropAllowed?: boolean;
   onClick?: () => void;
@@ -44,6 +46,7 @@ export function Ability({
         "is-drag-target": isDragTarget,
         "drag-started": dragStarted,
         "drop-allowed": dropAllowed,
+        readonly,
       })}
       style={
         {
@@ -58,7 +61,7 @@ export function Ability({
         setIsDragTarget(false);
         onDrop?.(event);
       }}
-      type="button"
+      tabIndex={readonly ? -1 : undefined}
     >
       <Image alt="" path={abilityImageUrl(ability)} />
     </button>

--- a/app/components/Ability.tsx
+++ b/app/components/Ability.tsx
@@ -62,6 +62,7 @@ export function Ability({
         onDrop?.(event);
       }}
       tabIndex={readonly ? -1 : undefined}
+      type="button"
     >
       <Image alt="" path={abilityImageUrl(ability)} />
     </button>

--- a/app/components/BuildCard.tsx
+++ b/app/components/BuildCard.tsx
@@ -213,7 +213,12 @@ function AbilitiesRowWithGear({
         className="build__gear"
       />
       {abilities.map((ability, i) => (
-        <Ability key={i} ability={ability} size={i === 0 ? "MAIN" : "SUB"} />
+        <Ability
+          key={i}
+          ability={ability}
+          size={i === 0 ? "MAIN" : "SUB"}
+          readonly
+        />
       ))}
     </>
   );

--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -808,6 +808,12 @@ dialog::backdrop {
   pointer-events: none;
 }
 
+.build__ability.readonly,
+.build__ability.readonly:active {
+  cursor: default;
+  transform: none;
+}
+
 .build__bottom-row {
   display: flex;
   height: 100%;


### PR DESCRIPTION
Fix issue where abilities appeared clickable when they were not by adding a `readonly` attribute set on for instances of `<Ability/>` in `<BuildCard/>`.

Issue was introduced in #971.

Fixes #981

https://user-images.githubusercontent.com/3038600/193729074-36cbe7da-c34e-446f-9986-8e6a3cdb8143.mov


