### PR TITLE
Fix incorrect StatCard title alignment

### DIFF
--- a/app/styles/analyzer.css
+++ b/app/styles/analyzer.css
@@ -121,6 +121,7 @@
   display: flex;
   justify-content: space-evenly;
   margin-top: var(--s-2);
+  margin-bottom: auto;
   gap: var(--s-1);
 }
 


### PR DESCRIPTION
When a StatCard displays an ability, the title is incorrectly positioned vertically at the bottom of the StatCard. After this change, it is aligned near the top.

Fixes #987

## Before

<img width="497" alt="CleanShot 2022-10-03 at 23 09 49@2x" src="https://user-images.githubusercontent.com/3038600/193746912-3632e5ab-ce4e-4131-965d-8c8b04dc505a.png">

## After

<img width="523" alt="CleanShot 2022-10-03 at 23 09 36@2x" src="https://user-images.githubusercontent.com/3038600/193746918-31964260-2b4c-4495-aaec-0cfc03ecf9c7.png">