### PR TITLE
Use fixed widths for BuildCard

### DIFF
--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -711,7 +711,7 @@ dialog::backdrop {
   display: grid;
   justify-content: center;
   gap: var(--s-3);
-  grid-template-columns: repeat(auto-fit, 15rem);
+  grid-template-columns: repeat(auto-fit, 240px);
 }
 
 .build {


### PR DESCRIPTION
fixes #993

Seems like it's caused by the browser's default font size. The ability card gets too small for the fixed width images.