### PR TITLE
Add participant count in user page results table

### DIFF
--- a/app/routes/u.$identifier/results.tsx
+++ b/app/routes/u.$identifier/results.tsx
@@ -15,7 +15,7 @@ export default function UserResultsPage() {
   const data = parentRoute.data as UserPageLoaderData;
 
   return (
-    <main className="u__results-main layout__main">
+    <main className="main layout__main">
       <Section className="u__results-section">
         <table>
           <thead>

--- a/app/routes/u.$identifier/results.tsx
+++ b/app/routes/u.$identifier/results.tsx
@@ -23,6 +23,7 @@ export default function UserResultsPage() {
               <th>{t("results.placing")}</th>
               <th>{t("results.team")}</th>
               <th>{t("results.tournament")}</th>
+              <th>{t("results.participants")}</th>
               <th>{t("results.date")}</th>
               <th>{t("results.mates")}</th>
             </tr>
@@ -37,6 +38,7 @@ export default function UserResultsPage() {
                     {result.eventName}
                   </Link>
                 </td>
+                <td>{result.participantCount}</td>
                 <td>
                   {databaseTimestampToDate(result.startTime).toLocaleDateString(
                     i18n.language,

--- a/app/styles/u.css
+++ b/app/styles/u.css
@@ -147,11 +147,6 @@
   font-weight: var(--bold);
 }
 
-.u__results-main {
-  max-width: 52rem;
-  margin: 0 auto;
-}
-
 .u__results-section {
   overflow-x: auto;
 }

--- a/public/locales/de/user.json
+++ b/public/locales/de/user.json
@@ -13,6 +13,7 @@
   "results.placing": "Platzierung",
   "results.team": "Team",
   "results.tournament": "Turnier",
+  "results.participants": "Teilnehmer",
   "results.date": "Datum",
   "results.mates": "Mitspieler",
 

--- a/public/locales/en/user.json
+++ b/public/locales/en/user.json
@@ -13,6 +13,7 @@
   "results.placing": "Placing",
   "results.team": "Team",
   "results.tournament": "Tournament",
+  "results.participants": "Participants",
   "results.date": "Date",
   "results.mates": "Mates",
 

--- a/translation-progress.md
+++ b/translation-progress.md
@@ -78,7 +78,7 @@
 
 ### 🟡 user.json
 
-**7/19**
+**7/20**
 
 <details>
 <summary>Missing</summary>
@@ -91,6 +91,7 @@
 - motion
 - stick
 - sens
+- results.participants
 - forms.errors.invalidCustomUrl.numbers
 - forms.errors.invalidCustomUrl.strangeCharacter
 - forms.errors.invalidCustomUrl.duplicate
@@ -178,7 +179,7 @@
 
 ### 🟢 user.json
 
-**19/19**
+**20/20**
 
 ---
 
@@ -270,7 +271,7 @@
 
 ### 🟡 user.json
 
-**7/19**
+**7/20**
 
 <details>
 <summary>Missing</summary>
@@ -283,6 +284,7 @@
 - motion
 - stick
 - sens
+- results.participants
 - forms.errors.invalidCustomUrl.numbers
 - forms.errors.invalidCustomUrl.strangeCharacter
 - forms.errors.invalidCustomUrl.duplicate
@@ -392,7 +394,7 @@
 
 ### 🟡 user.json
 
-**7/19**
+**7/20**
 
 <details>
 <summary>Missing</summary>
@@ -405,6 +407,7 @@
 - motion
 - stick
 - sens
+- results.participants
 - forms.errors.invalidCustomUrl.numbers
 - forms.errors.invalidCustomUrl.strangeCharacter
 - forms.errors.invalidCustomUrl.duplicate
@@ -465,7 +468,7 @@
 
 ### 🔴 user.json
 
-**0/19**
+**0/20**
 
 ---
 
@@ -647,7 +650,7 @@
 
 ### 🟡 user.json
 
-**7/19**
+**7/20**
 
 <details>
 <summary>Missing</summary>
@@ -660,6 +663,7 @@
 - motion
 - stick
 - sens
+- results.participants
 - forms.errors.invalidCustomUrl.numbers
 - forms.errors.invalidCustomUrl.strangeCharacter
 - forms.errors.invalidCustomUrl.duplicate
@@ -770,7 +774,7 @@
 
 ### 🟡 user.json
 
-**7/19**
+**7/20**
 
 <details>
 <summary>Missing</summary>
@@ -783,6 +787,7 @@
 - motion
 - stick
 - sens
+- results.participants
 - forms.errors.invalidCustomUrl.numbers
 - forms.errors.invalidCustomUrl.strangeCharacter
 - forms.errors.invalidCustomUrl.duplicate
@@ -869,9 +874,16 @@
 
 </details>
 
-### 🟢 user.json
+### 🟡 user.json
 
-**19/19**
+**19/20**
+
+<details>
+<summary>Missing</summary>
+
+- results.participants
+
+</details>
 
 ---
 
@@ -976,7 +988,7 @@
 
 ### 🟡 user.json
 
-**7/19**
+**7/20**
 
 <details>
 <summary>Missing</summary>
@@ -989,6 +1001,7 @@
 - motion
 - stick
 - sens
+- results.participants
 - forms.errors.invalidCustomUrl.numbers
 - forms.errors.invalidCustomUrl.strangeCharacter
 - forms.errors.invalidCustomUrl.duplicate
@@ -1099,7 +1112,7 @@
 
 ### 🟡 user.json
 
-**7/19**
+**7/20**
 
 <details>
 <summary>Missing</summary>
@@ -1112,6 +1125,7 @@
 - motion
 - stick
 - sens
+- results.participants
 - forms.errors.invalidCustomUrl.numbers
 - forms.errors.invalidCustomUrl.strangeCharacter
 - forms.errors.invalidCustomUrl.duplicate


### PR DESCRIPTION
Closes #864 

Notes:
- ~~The `check-translation-jsons` script already found changes on the current head, which is why there are two commits with changes to `translation-progress.md`.~~ Fixed after rebase
- Since the table became wider with this change I checked some smaller viewports and noticed that the scroll on overflow was broken for the table, so I fixed this by making sure the `main` element is normally just as wide as the parent.