### PR TITLE
Deactivate i18next interpolation escaping

### DIFF
--- a/app/modules/i18n/config.ts
+++ b/app/modules/i18n/config.ts
@@ -52,4 +52,7 @@ export const config = {
   fallbackLng: DEFAULT_LANGUAGE,
   defaultNS: "common",
   react: { useSuspense: false },
+  interpolation: {
+    escapeValue: false,
+  }
 };


### PR DESCRIPTION
As talked about in the ticket, the interpolation escaping i18next provides is not beneficial in combination with React in this case.

Fixes #994 