### PR TITLE
Fix edit badge dialog flickering

### DIFF
--- a/app/routes/badges/$id/edit.tsx
+++ b/app/routes/badges/$id/edit.tsx
@@ -72,8 +72,8 @@ export default function EditBadgePage() {
   const { badgeName } = useOutletContext<BadgeDetailsContext>();
 
   return (
-    <Dialog isOpen className="stack md">
-      <Form method="post">
+    <Dialog isOpen>
+      <Form method="post" className="stack md">
         <div>
           <h2 className="badges-edit__big-header">
             Editing winners of {badgeName}


### PR DESCRIPTION
Closes #826

To be honest, I'm not a 100% sure how the CSS caused the glitched behaviour.
However, the reason why this modal was behaving different than the others, is that the "stack md" classes were applied to the dialog itself, instead of the container inside.
I assume the blame then goes to the css overwriting the dialog's `display: block` with `display: flex`.