### PR TITLE
Allow users to copy a map pool of another event

### DIFF
--- a/app/db/models/calendar/findAllEventsWithMapPools.sql
+++ b/app/db/models/calendar/findAllEventsWithMapPools.sql
@@ -1,0 +1,12 @@
+select
+  "CalendarEvent"."id", 
+  "CalendarEvent"."name"
+from
+  "CalendarEvent"
+  join "MapPoolMap" on "CalendarEvent"."id" = "MapPoolMap"."calendarEventId"
+  left join "CalendarEventDate" on "CalendarEvent"."id" = "CalendarEventDate"."eventId"
+group by
+  "CalendarEvent"."id"
+order by
+  iif("CalendarEvent"."authorId" = @userId, 1 , 0) desc,
+  min("CalendarEventDate"."startTime") desc

--- a/app/db/models/calendar/queries.server.ts
+++ b/app/db/models/calendar/queries.server.ts
@@ -36,6 +36,7 @@ import upcomingEventsSql from "./upcomingEvents.sql";
 import createMapPoolMapSql from "./createMapPoolMap.sql";
 import deleteMapPoolMapsSql from "./deleteMapPoolMaps.sql";
 import findMapPoolByEventIdSql from "./findMapPoolByEventId.sql";
+import findAllEventsWithMapPoolsSql from "./findAllEventsWithMapPools.sql";
 
 const createStm = sql.prepare(createSql);
 const updateStm = sql.prepare(updateSql);
@@ -466,4 +467,11 @@ export function eventsToReport(authorId?: CalendarEvent["authorId"]) {
       lowerLimitTime: dateToDatabaseTimestamp(oneMonthAgo),
     }) as Array<Pick<CalendarEvent, "id" | "name">>
   ).map((row) => ({ id: row.id, name: row.name }));
+}
+
+const findAllEventsWithMapPoolsStm = sql.prepare(findAllEventsWithMapPoolsSql);
+export function findAllEventsWithMapPools(sortedForUserId?: number) {
+  return findAllEventsWithMapPoolsStm.all({
+    userId: sortedForUserId ?? -1,
+  }) as Pick<CalendarEvent, "id" | "name">[];
 }

--- a/app/routes/calendar/$id/map-pool.ts
+++ b/app/routes/calendar/$id/map-pool.ts
@@ -1,0 +1,12 @@
+import { json, type LoaderFunction } from "@remix-run/node";
+import { z } from "zod";
+import { db } from "~/db";
+import { actualNumber, id } from "~/utils/zod";
+
+export const loader: LoaderFunction = ({ params }) => {
+  const parsedParams = z
+    .object({ id: z.preprocess(actualNumber, id) })
+    .parse(params);
+
+  return json(db.calendarEvents.findMapPoolByEventId(parsedParams.id));
+};

--- a/app/routes/calendar/new.tsx
+++ b/app/routes/calendar/new.tsx
@@ -27,7 +27,7 @@ import type { Badge as BadgeType, CalendarEventTag } from "~/db/types";
 import { useIsMounted } from "~/hooks/useIsMounted";
 import { requireUser } from "~/modules/auth";
 import { i18next } from "~/modules/i18n";
-import type { ModeShort, StageId } from "~/modules/in-game-lists";
+import type { ModeShort } from "~/modules/in-game-lists";
 import {
   mapPoolToSerializedString,
   serializedStringToMapPool,
@@ -201,6 +201,7 @@ export const loader = async ({ request }: LoaderArgs) => {
 
   return json({
     managedBadges: db.badges.managedByUserId(user.id),
+    mapPoolTemplateEvents: db.calendarEvents.findAllEventsWithMapPools(user.id),
     eventToEdit: canEditEvent
       ? {
           ...eventToEdit,
@@ -544,26 +545,6 @@ function MapPoolSection() {
     Boolean(data.eventToEdit?.mapPool)
   );
 
-  const handleMapPoolChange = ({
-    mode,
-    stageId,
-  }: {
-    mode: ModeShort;
-    stageId: StageId;
-  }) => {
-    const newMapPool = mapPool[mode].includes(stageId)
-      ? {
-          ...mapPool,
-          [mode]: mapPool[mode].filter((id) => id !== stageId),
-        }
-      : {
-          ...mapPool,
-          [mode]: [...mapPool[mode], stageId],
-        };
-
-    setMapPool(newMapPool);
-  };
-
   return (
     <div className="w-full">
       {includeMapPool && (
@@ -579,7 +560,8 @@ function MapPoolSection() {
         {includeMapPool && (
           <MapPoolSelector
             mapPool={mapPool}
-            handleMapPoolChange={handleMapPoolChange}
+            handleMapPoolChange={setMapPool}
+            templateEvents={data.mapPoolTemplateEvents}
           />
         )}
       </div>

--- a/app/styles/maps.css
+++ b/app/styles/maps.css
@@ -19,6 +19,28 @@
   gap: var(--s-3);
 }
 
+.maps__template-row {
+  display: flex;
+  /* image width + gap */
+  margin-inline-start: calc(80px + var(--s-3));
+  justify-content: center;
+  align-items: flex-end;
+  gap: var(--s-2)
+}
+
+input.maps__template-event-input {
+  border: 2px solid var(--theme-info-transparent);
+  border-radius: var(--rounded);
+}
+
+input.maps__template-event-input.hasValue {
+  border: 2px solid var(--theme-info);
+}
+
+.maps__template-apply-button {
+  margin-bottom: 0.25rem;
+}
+
 .maps__stage-name-row {
   display: flex;
   flex-direction: column;
@@ -50,8 +72,8 @@
 .maps__mode-button {
   padding: 0;
   padding: var(--s-1-5);
-  border: none;
-  border-radius: var(--rounded);
+  border: 2px solid transparent;
+  border-radius: var(--rounded-full);
   background-color: var(--bg-darker);
   color: var(--theme);
   opacity: 1 !important;
@@ -60,6 +82,10 @@
 
 .maps__mode-button.selected {
   background-color: var(--theme-very-transparent);
+}
+
+.maps__mode-button.inTemplate {
+  border-color: var(--theme-info);
 }
 
 .maps__stage-image {

--- a/app/styles/vars.css
+++ b/app/styles/vars.css
@@ -32,6 +32,7 @@ html {
   --theme-secondary: hsl(85deg 66.7% 55.3%);
   --rounded: 16px;
   --rounded-sm: 10px;
+  --rounded-full: 200px;
   --fonts-xl: 1.5rem;
   --fonts-lg: 1.2rem;
   --fonts-md: 1rem;

--- a/app/utils/urls.ts
+++ b/app/utils/urls.ts
@@ -72,6 +72,8 @@ export const calendarEditPage = (eventId?: number) =>
   `/calendar/new${eventId ? `?eventId=${eventId}` : ""}`;
 export const calendarReportWinnersPage = (eventId: number) =>
   `/calendar/${eventId}/report-winners`;
+export const calendarEventMapPool = (eventId: number) =>
+  `/calendar/${eventId}/map-pool`;
 export const mapsPage = (eventId?: MapPoolMap["calendarEventId"]) =>
   `/maps${eventId ? `?eventId=${eventId}` : ""}`;
 export const articlePage = (slug: string) => `/a/${slug}`;

--- a/public/locales/de/calendar.json
+++ b/public/locales/de/calendar.json
@@ -19,6 +19,7 @@
   "forms.badges": "Abzeichen-Preis",
   "forms.badges.placeholder": "Wähle ein Abzeichen für das Event",
   "forms.mapPool": "Arenen-Pool",
+  "forms.mapPool.copyEventPool": "Event-Arenen-Pool kopieren",
 
   "forms.participantCount": "Anzahl Teilnehmer",
   "forms.reportResultsHeader": "Berichten der Ergebnisse von {{eventName}}",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -34,6 +34,7 @@
   "actions.delete": "Löschen",
   "actions.loadMore": "Mehr laden",
   "actions.close": "Schließen",
+  "actions.apply": "Anwenden",
 
   "maps.createMapList": "Arenen-Liste erstellen",
   "maps.halfSz": "50% Herrschaft",

--- a/public/locales/en/calendar.json
+++ b/public/locales/en/calendar.json
@@ -19,6 +19,7 @@
   "forms.badges": "Badge prizes",
   "forms.badges.placeholder": "Choose a badge prize",
   "forms.mapPool": "Map pool",
+  "forms.mapPool.copyEventPool": "Copy an event's pool",
 
   "forms.participantCount": "Participant count",
   "forms.reportResultsHeader": "Reporting results for {{eventName}}",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -35,6 +35,7 @@
   "actions.loadMore": "Load more",
   "actions.copyToClipboard": "Copy to clipboard",
   "actions.close": "Close",
+  "actions.apply": "Apply",
 
   "maps.createMapList": "Create map list",
   "maps.halfSz": "50% SZ",

--- a/translation-progress.md
+++ b/translation-progress.md
@@ -14,13 +14,20 @@
 
 **11/11**
 
-### 🟢 calendar.json
+### 🟡 calendar.json
 
-**46/46**
+**46/47**
+
+<details>
+<summary>Missing</summary>
+
+- forms.mapPool.copyEventPool
+
+</details>
 
 ### 🟡 common.json
 
-**55/60**
+**55/61**
 
 <details>
 <summary>Missing</summary>
@@ -30,6 +37,7 @@
 - auth.errors.discordPermissions
 - auth.errors.unknown
 - actions.close
+- actions.apply
 
 </details>
 
@@ -82,11 +90,11 @@
 
 ### 🟢 calendar.json
 
-**46/46**
+**47/47**
 
 ### 🟡 common.json
 
-**59/60**
+**60/61**
 
 <details>
 <summary>Missing</summary>
@@ -142,19 +150,20 @@
 
 ### 🟡 calendar.json
 
-**44/46**
+**44/47**
 
 <details>
 <summary>Missing</summary>
 
 - createMapList
 - forms.mapPool
+- forms.mapPool.copyEventPool
 
 </details>
 
 ### 🟡 common.json
 
-**48/60**
+**48/61**
 
 <details>
 <summary>Missing</summary>
@@ -167,6 +176,7 @@
 - auth.errors.unknown
 - actions.copyToClipboard
 - actions.close
+- actions.apply
 - maps.createMapList
 - maps.halfSz
 - maps.mapPool
@@ -263,19 +273,20 @@
 
 ### 🟡 calendar.json
 
-**44/46**
+**44/47**
 
 <details>
 <summary>Missing</summary>
 
 - createMapList
 - forms.mapPool
+- forms.mapPool.copyEventPool
 
 </details>
 
 ### 🟡 common.json
 
-**46/60**
+**46/61**
 
 <details>
 <summary>Missing</summary>
@@ -290,6 +301,7 @@
 - actions.loadMore
 - actions.copyToClipboard
 - actions.close
+- actions.apply
 - maps.createMapList
 - maps.halfSz
 - maps.mapPool
@@ -387,11 +399,11 @@
 
 ### 🔴 calendar.json
 
-**0/46**
+**0/47**
 
 ### 🔴 common.json
 
-**0/60**
+**0/61**
 
 ### 🔴 contributions.json
 
@@ -530,19 +542,20 @@
 
 ### 🟡 calendar.json
 
-**44/46**
+**44/47**
 
 <details>
 <summary>Missing</summary>
 
 - createMapList
 - forms.mapPool
+- forms.mapPool.copyEventPool
 
 </details>
 
 ### 🟡 common.json
 
-**46/60**
+**46/61**
 
 <details>
 <summary>Missing</summary>
@@ -557,6 +570,7 @@
 - actions.loadMore
 - actions.copyToClipboard
 - actions.close
+- actions.apply
 - maps.createMapList
 - maps.halfSz
 - maps.mapPool
@@ -653,19 +667,20 @@
 
 ### 🟡 calendar.json
 
-**44/46**
+**44/47**
 
 <details>
 <summary>Missing</summary>
 
 - createMapList
 - forms.mapPool
+- forms.mapPool.copyEventPool
 
 </details>
 
 ### 🟡 common.json
 
-**35/60**
+**35/61**
 
 <details>
 <summary>Missing</summary>
@@ -680,6 +695,7 @@
 - actions.loadMore
 - actions.copyToClipboard
 - actions.close
+- actions.apply
 - maps.createMapList
 - maps.halfSz
 - maps.mapPool
@@ -787,19 +803,20 @@
 
 ### 🟡 calendar.json
 
-**44/46**
+**44/47**
 
 <details>
 <summary>Missing</summary>
 
 - createMapList
 - forms.mapPool
+- forms.mapPool.copyEventPool
 
 </details>
 
 ### 🟡 common.json
 
-**48/60**
+**48/61**
 
 <details>
 <summary>Missing</summary>
@@ -812,6 +829,7 @@
 - auth.errors.unknown
 - actions.copyToClipboard
 - actions.close
+- actions.apply
 - maps.createMapList
 - maps.halfSz
 - maps.mapPool
@@ -887,19 +905,20 @@
 
 ### 🟡 calendar.json
 
-**44/46**
+**44/47**
 
 <details>
 <summary>Missing</summary>
 
 - createMapList
 - forms.mapPool
+- forms.mapPool.copyEventPool
 
 </details>
 
 ### 🟡 common.json
 
-**35/60**
+**35/61**
 
 <details>
 <summary>Missing</summary>
@@ -914,6 +933,7 @@
 - actions.loadMore
 - actions.copyToClipboard
 - actions.close
+- actions.apply
 - maps.createMapList
 - maps.halfSz
 - maps.mapPool
@@ -1021,19 +1041,20 @@
 
 ### 🟡 calendar.json
 
-**44/46**
+**44/47**
 
 <details>
 <summary>Missing</summary>
 
 - createMapList
 - forms.mapPool
+- forms.mapPool.copyEventPool
 
 </details>
 
 ### 🟡 common.json
 
-**35/60**
+**35/61**
 
 <details>
 <summary>Missing</summary>
@@ -1048,6 +1069,7 @@
 - actions.loadMore
 - actions.copyToClipboard
 - actions.close
+- actions.apply
 - maps.createMapList
 - maps.halfSz
 - maps.mapPool


### PR DESCRIPTION
Closes #1013 

I went a bit back and forth on how to write the data loading part. My thoughts:

- A backend full text search is probably the most scaling, but it seemed like a bit much to set up, and I have no experience with that. From what I found we would use the sqlite FTS 5 extension?
- Copying the current users approach of loading them all and keeping them in a cache seemed fine for the event map pools, but it would be weird if you add multiple events and cannot reference the one you added before. (At least I think that would be the case with the swr immutable? And re-fetching everything in a timed manner seemed also weird
- Adding a high limit (100-200?) to the sql seemed fine-ish but It would be kinda weird that you would suddenly not be able to not find some older events, if you always used them as reference

In the end I went for a compromise for now with loading all the events first as part of the route loader, but keeping the data as minimal as I could, only including the event ID and name, the actual map pool only gets fetched on-demand when it is selected, which is pretty fast.

With the UI I tried to use the blue info color to convey the connection between the combobox and which stages will be activated by the template.