### PR TITLE
Bug/persist user theme choice

### DIFF
--- a/app/components/layout/ColorModeToggle.tsx
+++ b/app/components/layout/ColorModeToggle.tsx
@@ -1,14 +1,20 @@
-import { Theme, useTheme } from "~/modules/theme";
+import { Theme, useTheme, THEME_LOCAL_STORAGE_KEY } from "~/modules/theme";
 import { MoonIcon } from "../icons/Moon";
 import { SunIcon } from "../icons/Sun";
 
 export function ColorModeToggle() {
   const [, setTheme] = useTheme();
 
+  /**
+   * Toggles the theme & then persists the user's preference to localStorage
+   */
   const toggleTheme = () => {
-    setTheme((prevTheme) =>
-      prevTheme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT
-    );
+    setTheme((prevTheme) => {
+      prevTheme = localStorage.getItem(THEME_LOCAL_STORAGE_KEY) ?? prevTheme;
+      const updatedTheme = prevTheme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT;
+      localStorage.setItem(THEME_LOCAL_STORAGE_KEY, updatedTheme);
+      return updatedTheme;
+    });
   };
 
   return (

--- a/app/modules/theme/index.ts
+++ b/app/modules/theme/index.ts
@@ -1,2 +1,2 @@
-export { Theme, ThemeHead, ThemeProvider, useTheme } from "./provider";
+export { Theme, ThemeHead, ThemeProvider, useTheme, THEME_LOCAL_STORAGE_KEY } from "./provider";
 export { action } from "./action.server";

--- a/cypress/e2e/misc.cy.ts
+++ b/cypress/e2e/misc.cy.ts
@@ -1,19 +1,73 @@
 export {};
 
+beforeEach(() => {
+  cy.clearLocalStorage();
+  cy.visit("/");
+});
+
+/**
+ * Note: function() is preferred over arrow functions for access to this.*
+ * Reference: https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Avoiding-the-use-of-this
+ */
 describe("404 page", () => {
-  it("should say 404 if accessing URL that doesn't exist", () => {
+  it("should say 404 if accessing URL that doesn't exist", function() {
     cy.visit("/plus/idonotexist", { failOnStatusCode: false });
     cy.contains("404");
   });
 });
 
 describe("theme switcher", () => {
-  it("should switch to light mode and remember it", () => {
-    cy.visit("/");
-    cy.get(".dark-mode-only").should("be.visible"); // moon svg icon
-    cy.getCy("theme-switch-button").click();
+  /**
+   * Attempting to import the constant from the Theme module breaks the Cypress tests"
+   * 
+   * import { THEME_LOCAL_STORAGE_KEY } from "~/modules/theme";
+   * 
+   * , so we have to hard-code this to test localStorage.
+   */
+  const THEME_LOCAL_STORAGE_KEY = "theme-preference";
+
+  it("should start on Light Mode and remember it", function() {
     cy.get(".light-mode-only").should("be.visible"); // sun svg icon
-    cy.reload();
-    cy.get(".light-mode-only").should("be.visible"); // sun svg icon again
+    cy.reload().then(() => {
+      cy.get(".light-mode-only").should("be.visible"); // sun svg icon again
+    });
+  });
+
+  it("should switch to Dark Mode and remember it", function() {
+    cy.get(".light-mode-only").should("be.visible"); // sun svg icon
+
+    cy.getCy("theme-switch-button").click().then(() => {
+      cy.get(".dark-mode-only").should("be.visible"); // moon svg icon
+      cy.reload().then(() => {
+        cy.get(".dark-mode-only").should("be.visible"); // moon svg icon again
+      });      
+    });
+  });
+
+  it("should start on Light Mode, switch to Dark Mode and remember it, then switch back to Light Mode properly", function() {
+    cy.get(".light-mode-only").should("be.visible"); // sun svg icon
+
+    cy.getCy("theme-switch-button").click().then(() => {
+      cy.get(".dark-mode-only").should("be.visible"); // moon svg icon
+      cy.reload().then(() => {
+        cy.get(".dark-mode-only").should("be.visible"); // moon svg icon again
+
+        cy.getCy("theme-switch-button").click().then(() => {
+          cy.get(".light-mode-only").should("be.visible"); // sun svg icon, second time
+        });
+      });
+    });
+  });
+
+  it("should start on Light Mode if the localStorage key is set to be light", function() {
+    localStorage.setItem(THEME_LOCAL_STORAGE_KEY, 'light');
+    cy.visit("/"); // Re-visit the page after localStorage key-value pair is set
+    cy.get(".light-mode-only").should("be.visible"); // moon svg icon
+  });
+
+  it("should start on Dark Mode if the localStorage key is set to be dark", function() {
+    localStorage.setItem(THEME_LOCAL_STORAGE_KEY, 'dark');
+    cy.visit("/"); // Re-visit the page after localStorage key-value pair is set
+    cy.get(".dark-mode-only").should("be.visible"); // moon svg icon
   });
 });

--- a/cypress/e2e/misc.cy.ts
+++ b/cypress/e2e/misc.cy.ts
@@ -5,12 +5,8 @@ beforeEach(() => {
   cy.visit("/");
 });
 
-/**
- * Note: function() is preferred over arrow functions for access to this.*
- * Reference: https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Avoiding-the-use-of-this
- */
 describe("404 page", () => {
-  it("should say 404 if accessing URL that doesn't exist", function() {
+  it("should say 404 if accessing URL that doesn't exist", () => {
     cy.visit("/plus/idonotexist", { failOnStatusCode: false });
     cy.contains("404");
   });
@@ -26,14 +22,14 @@ describe("theme switcher", () => {
    */
   const THEME_LOCAL_STORAGE_KEY = "theme-preference";
 
-  it("should start on Light Mode and remember it", function() {
+  it("should start on Light Mode and remember it", () => {
     cy.get(".light-mode-only").should("be.visible"); // sun svg icon
     cy.reload().then(() => {
       cy.get(".light-mode-only").should("be.visible"); // sun svg icon again
     });
   });
 
-  it("should switch to Dark Mode and remember it", function() {
+  it("should switch to Dark Mode and remember it", () => {
     cy.get(".light-mode-only").should("be.visible"); // sun svg icon
 
     cy.getCy("theme-switch-button").click().then(() => {
@@ -44,7 +40,7 @@ describe("theme switcher", () => {
     });
   });
 
-  it("should start on Light Mode, switch to Dark Mode and remember it, then switch back to Light Mode properly", function() {
+  it("should start on Light Mode, switch to Dark Mode and remember it, then switch back to Light Mode properly", () => {
     cy.get(".light-mode-only").should("be.visible"); // sun svg icon
 
     cy.getCy("theme-switch-button").click().then(() => {
@@ -59,13 +55,13 @@ describe("theme switcher", () => {
     });
   });
 
-  it("should start on Light Mode if the localStorage key is set to be light", function() {
+  it("should start on Light Mode if the localStorage key is set to be light", () => {
     localStorage.setItem(THEME_LOCAL_STORAGE_KEY, 'light');
     cy.visit("/"); // Re-visit the page after localStorage key-value pair is set
     cy.get(".light-mode-only").should("be.visible"); // moon svg icon
   });
 
-  it("should start on Dark Mode if the localStorage key is set to be dark", function() {
+  it("should start on Dark Mode if the localStorage key is set to be dark", () => {
     localStorage.setItem(THEME_LOCAL_STORAGE_KEY, 'dark');
     cy.visit("/"); // Re-visit the page after localStorage key-value pair is set
     cy.get(".dark-mode-only").should("be.visible"); // moon svg icon


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/1049

# Description of Changes

Theme choice from the user now persists via localStorage in that user's web browser.
- In other words, the user's theme choice persists even after ending that web browser's session and opening a brand new browser session.


Also updated the serverside-rendering workaround for the theme.
- Note that there was some unavoidable hardcoding that was needed here, as the workaround was already messy with some raw JS injection into the HTML element.

Also added a suite of Cypress E2E tests for the Theme Switcher.


## Notes

I've read about some kind of a flash issue with the wrong theme. I was not able to replicate this on my end, so please ensure that this theme flash issue does not occur. I will point this out in the code as well.


## Manual testing steps

1. Check out the latest version of this branch, run the application locally with `npm run dev`, visit the website ran locally (default URL when hosting locally: http://localhost:5800/), then click on the Theme Switch button.
2. Close the web browser, and make sure to **close all windows of the same type of web browser**. Example: if you visited the website on Google Chrome, you must close all Google Chrome instances.
3. Re-open a brand new instance of the same web browser, then re-visit the website ran locally.
4. Expectation: you should see that your selected theme persists.

If you do these exact same steps with the currently live version of the website (https://sendou.ink/), then you will see that the theme does not persist properly.


## Cypress test results when running them on my end:
![image](https://user-images.githubusercontent.com/15804376/198177275-d9076d12-7e6e-4b27-b227-618e434e5676.png)


## Browsers this was tested on:
- Google Chrome
- Firefox
- Microsoft Edge