### PR TITLE
Issue 1043: changed <div> tag to <h1> tag for semantic HTML for top-most UI buttons on active page

### DIFF
--- a/app/components/layout/index.tsx
+++ b/app/components/layout/index.tsx
@@ -68,7 +68,7 @@ export const Layout = React.memo(function Layout({
       </header>
       <Menu expanded={menuOpen} closeMenu={() => setMenuOpen(false)} />
       {activeNavItem && (
-        <div className="layout__page-title-header">
+        <h1 className="layout__page-title-header">
           <Image
             path={navIconUrl(activeNavItem.name)}
             width={28}
@@ -76,7 +76,7 @@ export const Layout = React.memo(function Layout({
             alt=""
           />
           {t(`pages.${activeNavItem.name}` as any)}
-        </div>
+        </h1>
       )}
       {children}
       <Footer patrons={patrons} />


### PR DESCRIPTION
# Link to Issue

https://github.com/Sendouc/sendou.ink/issues/1043

# Description of Changes

Issue 1043: changed `<div>` tag to `<h1>` tag for semantic HTML on the top-most UI buttons for an active page

The buttons look exactly the same before & after the change based on my testing =)