### PR TITLE
UserComboBox is now more strict

### DIFF
--- a/app/components/Combobox.tsx
+++ b/app/components/Combobox.tsx
@@ -68,12 +68,19 @@ export function Combobox<T extends Record<string, string | null | number>>({
     setLastSelectedOption(initialValue);
   }, [initialValue]);
 
+  // Reference for Fuse options: https://fusejs.io/api/options.html
+  const FUSE_OPTIONS = {
+    threshold: 0.42, // Empirically determined value to get an exact match for a Discord ID
+  };
+
   const filteredOptions = (() => {
     if (!query) return [];
 
     const fuse = new Fuse(options, {
+      ...FUSE_OPTIONS,
       keys: [...Object.keys(options[0] ?? {})],
     });
+
     return fuse
       .search(query)
       .slice(0, MAX_RESULTS_SHOWN)

--- a/app/components/Combobox.tsx
+++ b/app/components/Combobox.tsx
@@ -38,7 +38,7 @@ interface ComboboxProps<T> {
   clearsInputOnFocus?: boolean;
   onChange?: (selectedOption?: ComboboxOption<T>) => void;
   fullWidth?: boolean;
-  fuseOptions?: object;
+  fuseOptions?: Fuse.IFuseOptions<ComboboxOption<T>>;
 }
 
 export function Combobox<T extends Record<string, string | null | number>>({
@@ -53,7 +53,7 @@ export function Combobox<T extends Record<string, string | null | number>>({
   id,
   isLoading = false,
   fullWidth = false,
-  fuseOptions,
+  fuseOptions = {},
 }: ComboboxProps<T>) {
   const { t } = useTranslation();
 
@@ -69,10 +69,6 @@ export function Combobox<T extends Record<string, string | null | number>>({
     setSelectedOption(initialValue);
     setLastSelectedOption(initialValue);
   }, [initialValue]);
-
-  if (typeof fuseOptions === "undefined") {
-    fuseOptions = {};
-  }
 
   const filteredOptions = (() => {
     if (!query) return [];
@@ -172,6 +168,11 @@ export function Combobox<T extends Record<string, string | null | number>>({
   );
 }
 
+// Reference for Fuse options: https://fusejs.io/api/options.html
+const USER_COMBOBOX_FUSE_OPTIONS = {
+  threshold: 0.42, // Empirically determined value to get an exact match for a Discord ID
+};
+
 export function UserCombobox({
   inputName,
   initialUserId,
@@ -212,11 +213,6 @@ export function UserCombobox({
       <div className="text-sm text-error">{t("errors.genericReload")}</div>
     );
   }
-
-  // Reference for Fuse options: https://fusejs.io/api/options.html
-  const USER_COMBOBOX_FUSE_OPTIONS = {
-    threshold: 0.42, // Empirically determined value to get an exact match for a Discord ID
-  };
 
   return (
     <Combobox

--- a/app/components/Combobox.tsx
+++ b/app/components/Combobox.tsx
@@ -38,6 +38,7 @@ interface ComboboxProps<T> {
   clearsInputOnFocus?: boolean;
   onChange?: (selectedOption?: ComboboxOption<T>) => void;
   fullWidth?: boolean;
+  fuseOptions?: object;
 }
 
 export function Combobox<T extends Record<string, string | null | number>>({
@@ -52,6 +53,7 @@ export function Combobox<T extends Record<string, string | null | number>>({
   id,
   isLoading = false,
   fullWidth = false,
+  fuseOptions,
 }: ComboboxProps<T>) {
   const { t } = useTranslation();
 
@@ -68,16 +70,15 @@ export function Combobox<T extends Record<string, string | null | number>>({
     setLastSelectedOption(initialValue);
   }, [initialValue]);
 
-  // Reference for Fuse options: https://fusejs.io/api/options.html
-  const FUSE_OPTIONS = {
-    threshold: 0.42, // Empirically determined value to get an exact match for a Discord ID
-  };
+  if (typeof fuseOptions === "undefined") {
+    fuseOptions = {};
+  }
 
   const filteredOptions = (() => {
     if (!query) return [];
 
     const fuse = new Fuse(options, {
-      ...FUSE_OPTIONS,
+      ...fuseOptions,
       keys: [...Object.keys(options[0] ?? {})],
     });
 
@@ -212,6 +213,11 @@ export function UserCombobox({
     );
   }
 
+  // Reference for Fuse options: https://fusejs.io/api/options.html
+  const USER_COMBOBOX_FUSE_OPTIONS = {
+    threshold: 0.42, // Empirically determined value to get an exact match for a Discord ID
+  };
+
   return (
     <Combobox
       inputName={inputName}
@@ -223,6 +229,7 @@ export function UserCombobox({
       className={className}
       id={id}
       required={required}
+      fuseOptions={USER_COMBOBOX_FUSE_OPTIONS}
     />
   );
 }


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/914

# Description of Changes

Passed a FUSE_OPTIONS object to the Fuse() object.
- We can now adjust how "strict" the search is.
- We currently only adjust the `threshold` attribute of the FUSE_OPTIONS object

## Screenshot

With a `threshold` value of 0.42, this is what the search result looks like:

![image](https://user-images.githubusercontent.com/15804376/198861005-07075fcc-0915-40ef-a14a-361b3f61101d.png)

I tried with `threshold: 0.45` and it still gave more than 1 result, so I figured 0.42 is a good `threshold` value to start with.

## Reference

Docs for Fuse Options: https://fusejs.io/api/options.html