### PR TITLE
Only allow numbers as discrim

### DIFF
--- a/app/routes/u.$identifier/edit.tsx
+++ b/app/routes/u.$identifier/edit.tsx
@@ -96,7 +96,11 @@ const userEditActionSchema = z
     ),
     inGameNameDiscriminator: z.preprocess(
       falsyToNull,
-      z.string().length(USER.IN_GAME_NAME_DISCRIMINATOR_LENGTH).nullable()
+      z
+        .string()
+        .length(USER.IN_GAME_NAME_DISCRIMINATOR_LENGTH)
+        .refine((val) => /^[0-9]{4}$/.test(val))
+        .nullable()
     ),
   })
   .refine(


### PR DESCRIPTION
Manually sending a request currently allows users to input anything that is 4 characters as their discrim which can be seen [here](https://sendou.ink/u/illya). I have added a simple check to make sure this is no longer possible.