### PR TITLE
Make LanguageChanger respect existing search params

### DIFF
--- a/app/components/layout/LanguageChanger.tsx
+++ b/app/components/layout/LanguageChanger.tsx
@@ -1,11 +1,24 @@
+import { useSearchParams } from "@remix-run/react";
 import { useTranslation } from "~/hooks/useTranslation";
 import { languages } from "~/modules/i18n";
 import { LinkButton } from "../Button";
 import { GlobeIcon } from "../icons/Globe";
 import { Popover } from "../Popover";
 
+const addUniqueParam = (
+  oldParams: URLSearchParams,
+  name: string,
+  value: string
+): URLSearchParams => {
+  const paramsCopy = new URLSearchParams(oldParams);
+  paramsCopy.delete(name);
+  paramsCopy.append(name, value);
+  return paramsCopy;
+};
+
 export function LanguageChanger() {
   const { t, i18n } = useTranslation();
+  const [searchParams] = useSearchParams();
 
   return (
     <Popover
@@ -26,7 +39,7 @@ export function LanguageChanger() {
             className={
               i18n.language !== lang.code ? "text-main-forced" : undefined
             }
-            to={`?lng=${lang.code}`}
+            to={`?${addUniqueParam(searchParams, "lng", lang.code).toString()}`}
           >
             {lang.name}
           </LinkButton>


### PR DESCRIPTION
Closes #1096 

This fixes the issue, but it feels a little bit brute-force. I'm not sure what a better solution would be 🤔 

I guess one option would be not to use links at all, but to persist the language using a fetch/form and then somehow invalidate the root loader cache? (possibly by still setting the search param programatically, or maybe there is another option)