### PR TITLE
Add placement ordinal translation

### DIFF
--- a/app/components/Placement.tsx
+++ b/app/components/Placement.tsx
@@ -1,4 +1,4 @@
-import { getEnglishOrdinalSuffix } from "~/utils/strings";
+import { useTranslation } from "~/hooks/useTranslation";
 
 export type PlacementProps = {
   placement: number;
@@ -24,28 +24,35 @@ export function Placement({
   iconClassName,
   textClassName,
 }: PlacementProps) {
-  /* 
-        Placements are using english ordinal syntax only.
-        If wished for, we could look into properly adding translations here, but
-        english-style ordinals are commonly used internationally as well.
-    */
-  const ordinalSuffix = getEnglishOrdinalSuffix(placement);
+  const { t } = useTranslation(undefined, {});
+
+  // Remove assertion if types stop claiming result is "never".
+  const ordinalSuffix: string = t("results.placeSuffix", {
+    count: placement,
+    ordinal: true,
+    // no suffix is a better default than english
+    defaultValue: "",
+    fallbackLng: [],
+  });
+
+  const isSuperscript = ordinalSuffix.startsWith("^");
+  const ordinalSuffixText = ordinalSuffix.replace(/^\^/, "");
+
   const iconPath = getSpecialPlacementIconPath(placement);
 
   if (!iconPath) {
     return (
-      <span className={textClassName} lang="en-us">
+      <span className={textClassName}>
         {placement}
-        <sup>{ordinalSuffix}</sup>
+        {isSuperscript ? <sup>{ordinalSuffixText}</sup> : ordinalSuffixText}
       </span>
     );
   }
 
-  const placementString = `${placement}${ordinalSuffix}`;
+  const placementString = `${placement}${ordinalSuffixText}`;
 
   return (
     <img
-      lang="en-us"
       alt={placementString}
       title={placementString}
       src={iconPath}

--- a/app/utils/strings.ts
+++ b/app/utils/strings.ts
@@ -11,20 +11,6 @@ export function makeTitle(title: string | string[]) {
   return `${Array.isArray(title) ? title.join(" | ") : title} | sendou.ink`;
 }
 
-export function getEnglishOrdinalSuffix(num: number) {
-  const lastDigit = num % 10;
-  const last2Digits = num % 100;
-
-  if (lastDigit === 1 && last2Digits !== 11) {
-    return "st";
-  } else if (lastDigit === 2 && last2Digits !== 12) {
-    return "nd";
-  } else if (lastDigit === 3 && last2Digits !== 13) {
-    return "rd";
-  }
-  return "th";
-}
-
 export function semiRandomId() {
   return String(Math.random());
 }

--- a/public/locales/da/common.json
+++ b/public/locales/da/common.json
@@ -56,6 +56,7 @@
   "maps.template.preset.onlyMode": "Kun {{modeName}}",
 
   "results": "Resultater",
+  "results.placeSuffix": ".",
 
   "forms.name": "Navn",
   "forms.description": "Beskrivelse",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -58,6 +58,7 @@
   "maps.template.preset.onlyMode": "Nur {{modeName}}",
 
   "results": "Ergebnisse",
+  "results.placeSuffix": ".",
 
   "forms.name": "Name",
   "forms.description": "Beschreibung",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -60,6 +60,11 @@
 
   "results": "Results",
 
+  "results.placeSuffix_one": "^st",
+  "results.placeSuffix_two": "^nd",
+  "results.placeSuffix_few": "^rd",
+  "results.placeSuffix_other": "^th",
+
   "forms.name": "Name",
   "forms.description": "Description",
   "forms.errors.title": "Following errors need to be fixed",

--- a/public/locales/es-ES/common.json
+++ b/public/locales/es-ES/common.json
@@ -28,6 +28,7 @@
   "actions.loadMore": "Cargar más",
 
   "results": "Resultados",
+  "results.placeSuffix": "^o",
 
   "forms.name": "Nombre",
   "forms.description": "Descripción",

--- a/public/locales/es-US/common.json
+++ b/public/locales/es-US/common.json
@@ -28,6 +28,7 @@
   "actions.loadMore": "Cargar más",
 
   "results": "Resultados",
+  "results.placeSuffix": "^o",
 
   "forms.name": "Nombre",
   "forms.description": "Descripción",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -27,6 +27,8 @@
   "actions.delete": "Effacer",
 
   "results": "Résultats",
+  "results.placeSuffix_one": "^re",
+  "results.placeSuffix_other": "^e",
 
   "forms.name": "Nom",
   "forms.description": "Description",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -36,6 +36,7 @@
   "maps.tournamentMaplist": "Maak een toernooi levellijst (maps.iplabs.ink)",
 
   "results": "Uitslagen",
+  "results.placeSuffix": "e",
 
   "forms.name": "Naam",
   "forms.description": "Beschrijving",

--- a/translation-progress.md
+++ b/translation-progress.md
@@ -4,11 +4,11 @@
 
 ### 🟢 analyzer.json
 
-**112/112**
+**111/111**
 
 ### 🟢 badges.json
 
-**7/7**
+**6/6**
 
 ### 🟢 builds.json
 
@@ -20,7 +20,7 @@
 
 ### 🟡 common.json
 
-**76/82**
+**77/83**
 
 <details>
 <summary>Missing</summary>
@@ -60,11 +60,11 @@
 
 ### 🟢 analyzer.json
 
-**112/112**
+**111/111**
 
 ### 🟢 badges.json
 
-**7/7**
+**6/6**
 
 ### 🟢 builds.json
 
@@ -76,7 +76,7 @@
 
 ### 🟡 common.json
 
-**81/82**
+**82/83**
 
 <details>
 <summary>Missing</summary>
@@ -118,7 +118,7 @@
 
 ### 🟡 analyzer.json
 
-**92/112**
+**92/111**
 
 <details>
 <summary>Missing</summary>
@@ -129,7 +129,6 @@
 - stat.shootingRunSpeed
 - stat.shootingRunSpeedCharging
 - stat.shootingRunSpeedFullCharge
-- damage.toSplat_one
 - damage.NORMAL_MAX_FULL_CHARGE
 - damage.DIRECT_MIN
 - damage.DIRECT_MAX
@@ -148,7 +147,7 @@
 
 ### 🟢 badges.json
 
-**7/7**
+**6/6**
 
 ### 🟢 builds.json
 
@@ -168,7 +167,7 @@
 
 ### 🟡 common.json
 
-**48/82**
+**49/83**
 
 <details>
 <summary>Missing</summary>
@@ -285,7 +284,7 @@
 
 ### 🟡 analyzer.json
 
-**92/112**
+**92/111**
 
 <details>
 <summary>Missing</summary>
@@ -296,7 +295,6 @@
 - stat.shootingRunSpeed
 - stat.shootingRunSpeedCharging
 - stat.shootingRunSpeedFullCharge
-- damage.toSplat_one
 - damage.NORMAL_MAX_FULL_CHARGE
 - damage.DIRECT_MIN
 - damage.DIRECT_MAX
@@ -315,7 +313,7 @@
 
 ### 🟢 badges.json
 
-**7/7**
+**6/6**
 
 ### 🟢 builds.json
 
@@ -335,7 +333,7 @@
 
 ### 🟡 common.json
 
-**48/82**
+**49/83**
 
 <details>
 <summary>Missing</summary>
@@ -452,7 +450,7 @@
 
 ### 🟡 analyzer.json
 
-**92/112**
+**92/111**
 
 <details>
 <summary>Missing</summary>
@@ -463,7 +461,6 @@
 - stat.shootingRunSpeed
 - stat.shootingRunSpeedCharging
 - stat.shootingRunSpeedFullCharge
-- damage.toSplat_one
 - damage.NORMAL_MAX_FULL_CHARGE
 - damage.DIRECT_MIN
 - damage.DIRECT_MAX
@@ -482,7 +479,7 @@
 
 ### 🟢 badges.json
 
-**7/7**
+**6/6**
 
 ### 🟢 builds.json
 
@@ -502,7 +499,7 @@
 
 ### 🟡 common.json
 
-**47/82**
+**48/83**
 
 <details>
 <summary>Missing</summary>
@@ -629,11 +626,11 @@
 
 ### 🔴 analyzer.json
 
-**0/112**
+**0/111**
 
 ### 🔴 badges.json
 
-**0/7**
+**0/6**
 
 ### 🔴 builds.json
 
@@ -645,7 +642,7 @@
 
 ### 🔴 common.json
 
-**0/82**
+**0/83**
 
 ### 🔴 contributions.json
 
@@ -689,11 +686,11 @@
 
 ### 🟢 analyzer.json
 
-**112/112**
+**111/111**
 
 ### 🟢 badges.json
 
-**7/7**
+**6/6**
 
 ### 🟢 builds.json
 
@@ -705,7 +702,7 @@
 
 ### 🟡 common.json
 
-**75/82**
+**75/83**
 
 <details>
 <summary>Missing</summary>
@@ -714,6 +711,7 @@
 - header.language
 - header.loggedInAs
 - header.theme
+- results.placeSuffix
 - theme.light
 - theme.dark
 - theme.auto
@@ -753,11 +751,11 @@
 
 ### 🔴 analyzer.json
 
-**0/112**
+**0/111**
 
 ### 🟢 badges.json
 
-**7/7**
+**6/6**
 
 ### 🟢 builds.json
 
@@ -777,7 +775,7 @@
 
 ### 🟡 common.json
 
-**35/82**
+**35/83**
 
 <details>
 <summary>Missing</summary>
@@ -813,6 +811,7 @@
 - maps.template.preset.ANARCHY
 - maps.template.preset.ALL
 - maps.template.preset.onlyMode
+- results.placeSuffix
 - forms.errors.noSearchMatches
 - errors.genericReload
 - weapon.category.SHOOTERS
@@ -916,7 +915,7 @@
 
 ### 🟡 analyzer.json
 
-**95/112**
+**95/111**
 
 <details>
 <summary>Missing</summary>
@@ -924,7 +923,6 @@
 - objCalcAd
 - stat.specialLostSplattedByRP
 - stat.quickRespawnTimeSplattedByRP
-- damage.toSplat_one
 - damage.NORMAL_MAX_FULL_CHARGE
 - damage.DIRECT_MIN
 - damage.DIRECT_MAX
@@ -943,7 +941,7 @@
 
 ### 🟢 badges.json
 
-**7/7**
+**6/6**
 
 ### 🟢 builds.json
 
@@ -955,7 +953,7 @@
 
 ### 🟡 common.json
 
-**55/82**
+**56/83**
 
 <details>
 <summary>Missing</summary>
@@ -1046,7 +1044,7 @@
 
 ### 🟡 analyzer.json
 
-**102/112**
+**102/111**
 
 <details>
 <summary>Missing</summary>
@@ -1054,7 +1052,6 @@
 - objCalcAd
 - stat.specialLostSplattedByRP
 - stat.quickRespawnTimeSplattedByRP
-- damage.toSplat_one
 - damage.NORMAL_MAX_FULL_CHARGE
 - damage.DIRECT_MIN
 - damage.DIRECT_MAX
@@ -1066,7 +1063,7 @@
 
 ### 🟢 badges.json
 
-**7/7**
+**6/6**
 
 ### 🟢 builds.json
 
@@ -1078,7 +1075,7 @@
 
 ### 🟡 common.json
 
-**61/82**
+**61/83**
 
 <details>
 <summary>Missing</summary>
@@ -1099,6 +1096,7 @@
 - maps.template.preset.ANARCHY
 - maps.template.preset.ALL
 - maps.template.preset.onlyMode
+- results.placeSuffix
 - forms.errors.noSearchMatches
 - errors.genericReload
 - theme.light
@@ -1152,7 +1150,7 @@
 
 ### 🟡 analyzer.json
 
-**95/112**
+**95/111**
 
 <details>
 <summary>Missing</summary>
@@ -1160,7 +1158,6 @@
 - objCalcAd
 - stat.specialLostSplattedByRP
 - stat.quickRespawnTimeSplattedByRP
-- damage.toSplat_one
 - damage.NORMAL_MAX_FULL_CHARGE
 - damage.DIRECT_MIN
 - damage.DIRECT_MAX
@@ -1179,7 +1176,7 @@
 
 ### 🟢 badges.json
 
-**7/7**
+**6/6**
 
 ### 🟢 builds.json
 
@@ -1199,7 +1196,7 @@
 
 ### 🟡 common.json
 
-**35/82**
+**35/83**
 
 <details>
 <summary>Missing</summary>
@@ -1235,6 +1232,7 @@
 - maps.template.preset.ANARCHY
 - maps.template.preset.ALL
 - maps.template.preset.onlyMode
+- results.placeSuffix
 - forms.errors.noSearchMatches
 - errors.genericReload
 - weapon.category.SHOOTERS


### PR DESCRIPTION
Closes #1016 

I hope the creative use of `^` to detect superscript is fine. Pretty sure there are no languages that show "1^ place" 😅 

I tried adding some translations for languages where I could find a clear answer.

References: https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html + google results on "\<language\> rank ordinal suffix" or similar.
Unfortunately the unicode comparison alone doesn't go into detail in regards to grammatical gender. In some cases the grammatical gender of the described object changes the suffix, but in most cases this should then get the same gender as the translation for "place".