### PR TITLE
Fixed "Map Pool" title in events to use the appropriate localization value

### DIFF
--- a/app/routes/calendar/$id/index.tsx
+++ b/app/routes/calendar/$id/index.tsx
@@ -238,7 +238,7 @@ function MapPoolInfo() {
   if (!data.mapPool) return null;
 
   return (
-    <Section title="Map pool">
+    <Section title={t("calendar:forms.mapPool")}>
       <div className="event__map-pool-section">
         <MapPoolStages mapPool={new MapPool(data.mapPool)} />
         <LinkButton


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/1115

# Description

Fixed "Map Pool" title on active event pages to use the appropriate localization value

## Screenshot of the bug before the fix is applied:

![image](https://user-images.githubusercontent.com/15804376/201239660-4e8cc9fc-2b11-4453-92d5-860a11d876d1.png)


## Screenshot of the bug fix on an active event page:

![image](https://user-images.githubusercontent.com/15804376/201239606-8639dbd4-73e9-4cd5-9a00-e88bc9174082.png)
