### PR TITLE
Fixed a few calendar WeekLink element issues

### DIFF
--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -7,6 +7,13 @@
   margin-inline-start: auto;
 }
 
+.calendar__week__relative {
+  max-width: 3rem;
+  margin: 0 auto;
+  text-align: center;
+  white-space: pre-line;
+}
+
 .calendar__weeks {
   display: flex;
   align-items: center;
@@ -103,13 +110,6 @@
 .calendar__week:nth-child(7) {
   min-width: calc(var(--full-size-week-width) - 1.5rem);
   max-width: calc(var(--full-size-week-width) - 1.5rem);
-}
-
-.calendar__week__relative {
-  max-width: 3rem;
-  margin: 0 auto;
-  text-align: center;
-  white-space: pre-line;
 }
 
 .calendar__week__dash {

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -1,4 +1,3 @@
-/* stylelint-disable no-descending-specificity */
 .calendar__placeholder {
   height: 48rem;
 }
@@ -73,7 +72,7 @@
 /* Addresses spacing issues for translations with slightly longer strings
  * Issue: https://github.com/Sendouc/sendou.ink/issues/935
  */
-.calendar__week:nth-child(5) > .calendar__week__relative {
+.calendar__week:nth-child(5) .calendar__week__relative {
   max-width: 3.6rem;
 }
 
@@ -92,8 +91,8 @@
 /* Addresses spacing issues for translations with slightly longer strings
  * Issue: https://github.com/Sendouc/sendou.ink/issues/935
  */
-.calendar__week:nth-child(4) > .calendar__week__relative,
-.calendar__week:nth-child(6) > .calendar__week__relative {
+.calendar__week:nth-child(4) .calendar__week__relative,
+.calendar__week:nth-child(6) .calendar__week__relative {
   max-width: 3.2rem;
 }
 

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -81,6 +81,15 @@
   font-size: var(--fonts-xxs);
 }
 
+/* Addresses asymmetric elements mentioned in this issue:
+ * https://github.com/Sendouc/sendou.ink/issues/1117
+ */
+.calendar__week:nth-child(3),
+.calendar__week:nth-child(7) {
+  min-width: calc(var(--full-size-week-width) - 1.5rem);
+  max-width: calc(var(--full-size-week-width) - 1.5rem);
+}
+
 .calendar__week__relative {
   max-width: 3rem;
   margin: 0 auto;

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -72,7 +72,7 @@
 /* Addresses spacing issues for translations with slightly longer strings
  * Issue: https://github.com/Sendouc/sendou.ink/issues/935
  */
-.calendar__week__relative > .calendar__week:nth-child(5) {
+.calendar__week:nth-child(5) > .calendar__week__relative {
   max-width: 3.6rem;
 }
 
@@ -91,8 +91,8 @@
 /* Addresses spacing issues for translations with slightly longer strings
  * Issue: https://github.com/Sendouc/sendou.ink/issues/935
  */
-.calendar__week__relative > calendar__week:nth-child(4),
-.calendar__week__relative > calendar__week:nth-child(6) {
+.calendar__week:nth-child(4) > .calendar__week__relative,
+.calendar__week:nth-child(6) > .calendar__week__relative {
   max-width: 3.2rem;
 }
 
@@ -103,13 +103,6 @@
 .calendar__week:nth-child(7) {
   min-width: calc(var(--full-size-week-width) - 1.5rem);
   max-width: calc(var(--full-size-week-width) - 1.5rem);
-}
-
-.calendar__week__relative {
-  max-width: 3rem;
-  margin: 0 auto;
-  text-align: center;
-  white-space: pre-line;
 }
 
 .calendar__week__dash {
@@ -192,4 +185,11 @@
   font-size: var(--fonts-xs);
   padding-block-end: var(--s-2);
   text-align: center;
+}
+
+.calendar__week__relative {
+  max-width: 3rem;
+  margin: 0 auto;
+  text-align: center;
+  white-space: pre-line;
 }

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -72,7 +72,7 @@
 /* Addresses spacing issues for translations with slightly longer strings
  * Issue: https://github.com/Sendouc/sendou.ink/issues/935
  */
-.calendar__week:nth-child(5) > .calendar__week__relative {
+.calendar__week__relative > .calendar__week:nth-child(5) {
   max-width: 3.6rem;
 }
 
@@ -91,8 +91,8 @@
 /* Addresses spacing issues for translations with slightly longer strings
  * Issue: https://github.com/Sendouc/sendou.ink/issues/935
  */
-.calendar__week:nth-child(4) > .calendar__week__relative,
-.calendar__week:nth-child(6) > .calendar__week__relative {
+.calendar__week__relative > calendar__week:nth-child(4),
+.calendar__week__relative > calendar__week:nth-child(6) {
   max-width: 3.2rem;
 }
 

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -86,8 +86,7 @@
  */
 .calendar__week:nth-child(3),
 .calendar__week:nth-child(7) {
-  min-width: calc(var(--full-size-week-width) - 1.5rem);
-  max-width: calc(var(--full-size-week-width) - 1.5rem);
+  width: calc(var(--full-size-week-width) - 1.5rem);
 }
 
 .calendar__week__relative {

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -86,7 +86,8 @@
  */
 .calendar__week:nth-child(3),
 .calendar__week:nth-child(7) {
-  width: calc(var(--full-size-week-width) - 1.5rem);
+  min-width: calc(var(--full-size-week-width) - 1.5rem);
+  max-width: calc(var(--full-size-week-width) - 1.5rem);
 }
 
 .calendar__week__relative {

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -1,3 +1,4 @@
+/* stylelint-disable no-descending-specificity */
 .calendar__placeholder {
   height: 48rem;
 }
@@ -105,6 +106,13 @@
   max-width: calc(var(--full-size-week-width) - 1.5rem);
 }
 
+.calendar__week__relative {
+  max-width: 3rem;
+  margin: 0 auto;
+  text-align: center;
+  white-space: pre-line;
+}
+
 .calendar__week__dash {
   line-height: 0.8;
 }
@@ -185,11 +193,4 @@
   font-size: var(--fonts-xs);
   padding-block-end: var(--s-2);
   text-align: center;
-}
-
-.calendar__week__relative {
-  max-width: 3rem;
-  margin: 0 auto;
-  text-align: center;
-  white-space: pre-line;
 }

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -69,6 +69,13 @@
   font-size: var(--fonts-sm);
 }
 
+/* Addresses spacing issues for translations with slightly longer strings
+ * Issue: https://github.com/Sendouc/sendou.ink/issues/935
+ */
+.calendar__week:nth-child(5) > .calendar__week__relative {
+  max-width: 3.6rem;
+}
+
 .calendar__week:nth-child(4),
 .calendar__week:nth-child(6) {
   min-width: calc(var(--full-size-week-width) - 1rem);
@@ -81,8 +88,16 @@
   font-size: var(--fonts-xxs);
 }
 
-/* Addresses asymmetric elements mentioned in this issue:
- * https://github.com/Sendouc/sendou.ink/issues/1117
+/* Addresses spacing issues for translations with slightly longer strings
+ * Issue: https://github.com/Sendouc/sendou.ink/issues/935
+ */
+.calendar__week:nth-child(4) > .calendar__week__relative,
+.calendar__week:nth-child(6) > .calendar__week__relative {
+  max-width: 3.2rem;
+}
+
+/* Addresses asymmetric elements.
+ * Issue: https://github.com/Sendouc/sendou.ink/issues/1117
  */
 .calendar__week:nth-child(3),
 .calendar__week:nth-child(7) {


### PR DESCRIPTION
# Linked Issues

https://github.com/Sendouc/sendou.ink/issues/935
https://github.com/Sendouc/sendou.ink/issues/1117

# Description of  Changes

Fixed calendar week link element widths not being symmetric for the left-most and right-most elements (https://github.com/Sendouc/sendou.ink/issues/1117)

I had to slightly increase the size of the 3rd and 7th (left-most and right-most visible) calendar link elements to fix this as properly as possible to accommodate different languages & screen resolutions. Keeping the dimensions the same as the live website for the smaller calendar link element simply wasn't feasible.

Additionally, I have to overwrite `min-width` and `max-width` to still properly keep the text inside the calendar link element for certain languages (e.g., Japanese). If I only defined a `width` element for the 3rd and 7th child elements (and did not redefine `min-width` and `max-width`), we would get a visual bug on certain screen resolutions for certain languages. Example:

![image](https://user-images.githubusercontent.com/15804376/201254442-b4cba818-fd8c-4622-9a3f-e426d0f0c771.png)

I also fixed the French localization (and most likely fixed the Russian localization) edge case(s) for string contents overflowing the element container by slightly increasing the max-width (for: https://github.com/Sendouc/sendou.ink/issues/935). This still looks fine on 375px width screens.

## Testing Notes

I briefly tested this fix for all languages & at a reasonably-sized phone width in the web browser dev tools tab (at a width of 375px), and everything lines up well. I also briefly scrolled left and right a reasonably sane amount to check that there weren't any obvious edge cases.

## Screenshots

- Smallest phone screen width on Google Chrome dev tools, English language:
![image](https://user-images.githubusercontent.com/15804376/201254777-614d3ce2-4562-45cf-9478-ade7ee16fc7f.png)

- Smallest phone screen width on Google Chrome dev tools, Japanese language:
![image](https://user-images.githubusercontent.com/15804376/201254824-aeb73e8b-9be5-425f-9e48-a837e9172db4.png)

- Smallest phone screen width on Google Chrome dev tools, French language (for https://github.com/Sendouc/sendou.ink/issues/935):
![image](https://user-images.githubusercontent.com/15804376/201445937-b933e63f-7450-4452-b5df-0223e56f7373.png)

- Smallest phone screen width on Google Chrome dev tools, Russian language (for https://github.com/Sendouc/sendou.ink/issues/935):
![image](https://user-images.githubusercontent.com/15804376/201445990-7fc2337f-8702-4960-b027-f900b932776d.png)

- Regular screen, English:
![image](https://user-images.githubusercontent.com/15804376/201254492-7e8f6b3b-9106-4146-8a17-8776ee3895bd.png)

- Regular screen, Japanese:
![image](https://user-images.githubusercontent.com/15804376/201254523-526dcaac-3685-4723-95e2-11bfab95a1a2.png)

