### PR TITLE
Fixed flicker with combobox issue using unstable_shouldReload()

### DIFF
--- a/app/routes/analyzer.tsx
+++ b/app/routes/analyzer.tsx
@@ -67,9 +67,7 @@ export const handle: SendouRouteHandle = {
 };
 
 // Resolves this Github issue: https://github.com/Sendouc/sendou.ink/issues/1053
-export const unstable_shouldReload: ShouldReloadFunction = ({ url }) => {
-  return Boolean(url) && !url.searchParams.get("weapon");
-};
+export const unstable_shouldReload: ShouldReloadFunction = () => false;
 
 export default function BuildAnalyzerPage() {
   const { t } = useTranslation(["analyzer", "common", "weapons"]);

--- a/app/routes/analyzer.tsx
+++ b/app/routes/analyzer.tsx
@@ -1,4 +1,5 @@
 import { type LinksFunction, type MetaFunction } from "@remix-run/node";
+import type { ShouldReloadFunction } from "@remix-run/react";
 import { Link } from "@remix-run/react";
 import * as React from "react";
 import { useTranslation } from "~/hooks/useTranslation";
@@ -63,6 +64,11 @@ export const links: LinksFunction = () => {
 export const handle: SendouRouteHandle = {
   i18n: ["weapons", "analyzer"],
   navItemName: "analyzer",
+};
+
+// Resolves this Github issue: https://github.com/Sendouc/sendou.ink/issues/1053
+export const unstable_shouldReload: ShouldReloadFunction = ({ url }) => {
+  return Boolean(url) && !url.searchParams.get("weapon");
 };
 
 export default function BuildAnalyzerPage() {


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/1053

# Description

Fixed a flicker issue with the Weapon Combobox component.

To fix this, I've added `unstable_shouldReload()` in `app\routes\analyzer.tsx`.

# Manual testing

To replicate the bug reliably in the live version of the website, I enabled low-end mobile throttling in my Google Chrome's web browser debugging tools. By doing this, I can visibly see the flicker every time I change my search selection in the Weapon Combobox.

I did the same thing after implementing my fix on the locally hosted application & could no longer replicate this issue.

# References
- Remix docs with regards to the `unstable_shouldReload()` function https://remix.run/docs/en/v1/api/conventions#never-reloading-the-root
- Discussion on the Remix Github project that talks about this issue: https://github.com/remix-run/remix/discussions/2700