### PR TITLE
Re-enable bulk edit controls for maplist pools when logged out

### DIFF
--- a/app/components/MapPoolSelector.tsx
+++ b/app/components/MapPoolSelector.tsx
@@ -31,10 +31,11 @@ export type MapPoolSelectorProps = {
   recentEvents?: SerializedMapPoolEvent[];
   initialEvent?: Pick<CalendarEvent, "id" | "name">;
   title?: string;
-  noTitle?: boolean;
   modesToInclude?: ModeShort[];
   info?: React.ReactNode;
   footer?: React.ReactNode;
+  /** Enables clear button, template selection, and toggling a whole stage */
+  allowBulkEdit?: boolean;
 };
 
 export function MapPoolSelector({
@@ -46,10 +47,10 @@ export function MapPoolSelector({
   recentEvents,
   initialEvent,
   title,
-  noTitle = false,
   modesToInclude,
   info,
   footer,
+  allowBulkEdit = false,
 }: MapPoolSelectorProps) {
   const { t } = useTranslation();
 
@@ -111,29 +112,29 @@ export function MapPoolSelector({
     assertType<never, typeof template>();
   };
 
-  const includeFancyControls = Boolean(recentEvents);
-
   return (
     <fieldset className={className}>
-      {!noTitle && <legend>{title ?? t("maps.mapPool")}</legend>}
-      {includeFancyControls && (
+      {Boolean(title) && <legend>{title}</legend>}
+      {Boolean(handleRemoval || allowBulkEdit) && (
         <div className="stack horizontal sm justify-end">
           {handleRemoval && (
             <Button variant="minimal" onClick={handleRemoval}>
               {t("actions.remove")}
             </Button>
           )}
-          <Button
-            variant="minimal-destructive"
-            disabled={mapPool.isEmpty()}
-            onClick={handleClear}
-          >
-            {t("actions.clear")}
-          </Button>
+          {allowBulkEdit && (
+            <Button
+              variant="minimal-destructive"
+              disabled={mapPool.isEmpty()}
+              onClick={handleClear}
+            >
+              {t("actions.clear")}
+            </Button>
+          )}
         </div>
       )}
       <div className="stack md">
-        {includeFancyControls && (
+        {allowBulkEdit && (
           <div className="maps__template-selection">
             <MapPoolTemplateSelect
               value={template}
@@ -152,7 +153,7 @@ export function MapPoolSelector({
         <MapPoolStages
           mapPool={mapPool}
           handleMapPoolChange={handleStageModesChange}
-          includeFancyControls={includeFancyControls}
+          allowBulkEdit={allowBulkEdit}
           modesToInclude={modesToInclude}
           preselectedMapPool={preselectedMapPool}
         />
@@ -165,7 +166,7 @@ export function MapPoolSelector({
 export type MapPoolStagesProps = {
   mapPool: MapPool;
   handleMapPoolChange?: (newMapPool: MapPool) => void;
-  includeFancyControls?: boolean;
+  allowBulkEdit?: boolean;
   modesToInclude?: ModeShort[];
   preselectedMapPool?: MapPool;
 };
@@ -173,7 +174,7 @@ export type MapPoolStagesProps = {
 export function MapPoolStages({
   mapPool,
   handleMapPoolChange,
-  includeFancyControls = true,
+  allowBulkEdit = false,
   modesToInclude,
   preselectedMapPool,
 }: MapPoolStagesProps) {
@@ -313,7 +314,7 @@ export function MapPoolStages({
                   );
                 })}
               {!isPresentational &&
-                includeFancyControls &&
+                allowBulkEdit &&
                 (mapPool.hasStage(stageId) ? (
                   <Button
                     key="clear"

--- a/app/routes/calendar/new.tsx
+++ b/app/routes/calendar/new.tsx
@@ -651,9 +651,11 @@ function MapPoolSection() {
       <MapPoolSelector
         className="w-full"
         mapPool={mapPool}
+        title={t("common:maps.mapPool")}
         handleRemoval={() => setIncludeMapPool(false)}
         handleMapPoolChange={setMapPool}
         recentEvents={recentEventsWithMapPools}
+        allowBulkEdit
       />
     </>
   ) : (

--- a/app/routes/maps.tsx
+++ b/app/routes/maps.tsx
@@ -122,9 +122,11 @@ export default function MapListPage() {
       ) : (
         <MapPoolSelector
           mapPool={mapPool}
+          title={t("common:maps.mapPool")}
           handleMapPoolChange={handleMapPoolChange}
           recentEvents={data.recentEventsWithMapPools}
           initialEvent={data.calendarEvent}
+          allowBulkEdit
         />
       )}
       <a

--- a/app/routes/to.$identifier/index.tsx
+++ b/app/routes/to.$identifier/index.tsx
@@ -285,7 +285,6 @@ function MapPoolSection() {
             mapPool={counterpickMapPool}
             handleMapPoolChange={setCounterpickMapPool}
             className="bg-transparent-important"
-            noTitle
             modesToInclude={["SZ", "TC", "RM", "CB"]}
             preselectedMapPool={new MapPool(data.tieBreakerMapPool)}
             info={


### PR DESCRIPTION
I also refactored the `noTitle` prop away by not falling back to a default. Mainly to avoid confusion when e.g. setting `title` and `noTitle` together, and because I think not setting a title is a nicer API for not showing one.