### PR TITLE
External links are now opened in a new tab

### DIFF
--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -81,6 +81,8 @@ export function LinkButton({
         className={clsx("button", variant, { tiny }, className)}
         href={to as string}
         data-cy={testId}
+        target="_blank"
+        rel="noreferrer"
       >
         {children}
       </a>


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/1134

# Description

External links are now opened in a new tab.
- Done via adding the HTML attribute `target="_blank"` to the `<a />` tag for external links
- Note that `rel="noreferrer"` is needed to pass an ESLint check due to security concerns

# References

Opening links in a new tab in React: https://bobbyhadz.com/blog/react-open-link-in-new-tab#open-a-link-in-a-new-tab-in-react

`rel="noreferrer"` attribute & security vulnerabilities if you don't include it: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md