### PR TITLE
Temporary solution for dropdown arrow in `<select />` elements for Light Mode

### DIFF
--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -269,6 +269,12 @@ select {
   padding-inline: var(--s-3) var(--s-7);
 }
 
+/* Temporary solution for issue: https://github.com/Sendouc/sendou.ink/issues/1141 */
+.light select {
+  /* TODO: Get color from CSS var */
+  background-image: url('data:image/svg+xml;utf8,<svg width="1rem" color="rgb(0 0 0 / 55%)" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>');
+}
+
 select::selection {
   overflow: hidden;
   font-weight: bold;


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/1141

# Description of Changes

Temporary solution for dropdown arrow in `<select />` elements for Light Mode.

I had to use a `.light select {}` CSS selector to do this at the moment, since there are some challenges in passing CSS vars to SVGs if they are used in a `background-image` CSS property. It most likely isn't the best solution, but IMO it's an acceptable one for the time being.

As for the color used, it's just `(0, 0, 0)` with 55% transparency - the exact same analog to the current setting being used for dark mode, `(255, 255, 255)` with 55% transparency

## Screenshot 

![image](https://user-images.githubusercontent.com/15804376/202869383-66189536-4a42-4d75-888e-159ce4274bbf.png)
