### PR TITLE
Fixed Calendar WeekLink element CSS styling

### DIFF
--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -22,8 +22,8 @@
 .calendar__week {
   display: flex;
   min-width: calc(var(--full-size-week-width) - 2rem);
-  min-height: calc(var(--full-size-week-height) - 3rem);
   height: auto;
+  min-height: calc(var(--full-size-week-height) - 3rem);
   flex-direction: column;
   justify-content: space-between;
   padding: var(--s-1-5);

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -22,7 +22,8 @@
 .calendar__week {
   display: flex;
   min-width: calc(var(--full-size-week-width) - 2rem);
-  height: calc(var(--full-size-week-height) - 2rem);
+  min-height: calc(var(--full-size-week-height) - 3rem);
+  height: auto;
   flex-direction: column;
   justify-content: space-between;
   padding: var(--s-1-5);
@@ -60,7 +61,7 @@
 
 .calendar__week:nth-child(5) {
   min-width: var(--full-size-week-width);
-  height: var(--full-size-week-height);
+  min-height: var(--full-size-week-height);
   color: var(--text);
   font-size: var(--fonts-sm);
 }
@@ -72,7 +73,7 @@
 .calendar__week:nth-child(4),
 .calendar__week:nth-child(6) {
   min-width: calc(var(--full-size-week-width) - 1rem);
-  height: calc(var(--full-size-week-height) - 1rem);
+  min-height: calc(var(--full-size-week-height) - 1rem);
   font-size: var(--fonts-xs);
 }
 

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -23,7 +23,7 @@
   display: flex;
   min-width: calc(var(--full-size-week-width) - 2rem);
   height: auto;
-  min-height: calc(var(--full-size-week-height) - 3rem);
+  min-height: calc(var(--full-size-week-height) - 2rem);
   flex-direction: column;
   justify-content: space-between;
   padding: var(--s-1-5);


### PR DESCRIPTION
# Linked Issues

https://github.com/Sendouc/sendou.ink/issues/935
https://github.com/Sendouc/sendou.ink/issues/1117

# Description of  Changes

Fixed Calendar WeekLink element CSS styling by adjusting height & min-height dynamically
- I believe this same change also fixed calendar week link element widths not being symmetric for the left-most and right-most elements (likely due to the auto-scaling)

## Testing Notes

I briefly tested this fix for all languages & at a reasonably-sized phone width in the web browser dev tools tab (at a width of 375px) for a small phone, and everything lines up well. I also briefly scrolled left and right a reasonably sane amount to check that there weren't any obvious edge cases.

## Screenshots

- Full size, French: 
![image](https://user-images.githubusercontent.com/15804376/203647050-b80c3821-10d6-44c1-848f-0d0bd28d8444.png)

- Full size, English: 
![image](https://user-images.githubusercontent.com/15804376/203647069-a505139e-20d0-4351-8f9f-7da1512ae1fc.png)

- Full size, Japanese: 
![image](https://user-images.githubusercontent.com/15804376/203647108-0a611c01-6c39-4e9b-84a5-9ac4767f8443.png)

- Full size, Russian: 
![image](https://user-images.githubusercontent.com/15804376/203647137-8fc85762-58db-46e0-8b99-9adef5737517.png)

- Small phone size, French: 
![image](https://user-images.githubusercontent.com/15804376/203647241-66f9209f-ce7b-4f5e-9147-b82a5e8bf0f1.png)

- Small phone size, English: 
![image](https://user-images.githubusercontent.com/15804376/203647280-71442994-08dc-4158-b19b-cea7e2417099.png)

- Small phone size, Japanese: 
![image](https://user-images.githubusercontent.com/15804376/203647335-7058e6ee-3519-45de-9574-224e7ea2a68b.png)

- Small phone size, Russian: 
![image](https://user-images.githubusercontent.com/15804376/203647184-b985c2e9-9d75-4e6f-9e8a-482f4b0f4e9a.png)





