### PR TITLE
WIP:Planner - proof-of-concept for rendering extra locked images for certain modes

### DIFF
--- a/app/components/Planner.tsx
+++ b/app/components/Planner.tsx
@@ -138,7 +138,7 @@ export default function Planner() {
         for (const clamPoint of scorchedGorgeClams.clam_points) {
           if (!clamPoint) continue;
 
-          // Clams on top-right half
+          // Clams on bottom-left half
           handleAddImage({
             src: scorchedGorgeClams.icon_path,
             size: scorchedGorgeClams.icon_size,
@@ -146,12 +146,13 @@ export default function Planner() {
             point: clamPoint
           });
 
+          // I know these aren't type-safe yet, this is just a proof-of-concept
           const mirroredPoint = [0, 0];
           mirroredPoint[0] = clamPoint[0] - 2*(clamPoint[0] - scorchedGorgeClams.center_pos_symmetry[0]);
           mirroredPoint[1] = clamPoint[1] - 2*(clamPoint[1] - scorchedGorgeClams.center_pos_symmetry[1]);
           console.warn(mirroredPoint);
 
-          // Mirrored clams through center point of symmetry
+          // Mirror clams through center point of symmetry
           handleAddImage({
             src: scorchedGorgeClams.icon_path,
             size: scorchedGorgeClams.icon_size,

--- a/app/components/Planner.tsx
+++ b/app/components/Planner.tsx
@@ -26,6 +26,23 @@ import {
 import { Button } from "./Button";
 import { Image } from "./Image";
 
+const scorchedGorgeClams = {
+  "icon_path": "img/modes/CB.png",
+  "icon_size": [24, 24],
+  "center_pos_symmetry": [850, 430],
+  "clam_points": [
+    [630, 690],
+    [646, 610],
+    [680, 570],
+    [725, 580],
+    [775, 560],
+    [770, 435],
+    [721, 490],
+    [671, 375],
+    [815, 470],
+  ]
+}
+
 export default function Planner() {
   const { t } = useTranslation(["common", "weapons"]);
   const { i18n } = useTranslation();
@@ -115,6 +132,34 @@ export default function Planner() {
         isLocked: true,
         point: [65, 20],
       });
+
+      // Clam Blitz: add clams. Proof-of-concept for Scorched Gorge
+      if (modeShort === "CB") {
+        for (const clamPoint of scorchedGorgeClams.clam_points) {
+          if (!clamPoint) continue;
+
+          // Clams on top-right half
+          handleAddImage({
+            src: scorchedGorgeClams.icon_path,
+            size: scorchedGorgeClams.icon_size,
+            isLocked: true,
+            point: clamPoint
+          });
+
+          const mirroredPoint = [0, 0];
+          mirroredPoint[0] = clamPoint[0] - 2*(clamPoint[0] - scorchedGorgeClams.center_pos_symmetry[0]);
+          mirroredPoint[1] = clamPoint[1] - 2*(clamPoint[1] - scorchedGorgeClams.center_pos_symmetry[1]);
+          console.warn(mirroredPoint);
+
+          // Mirrored clams through center point of symmetry
+          handleAddImage({
+            src: scorchedGorgeClams.icon_path,
+            size: scorchedGorgeClams.icon_size,
+            isLocked: true,
+            point: mirroredPoint
+          });
+        }        
+      }
     },
     [app, handleAddImage]
   );
@@ -164,7 +209,7 @@ function StageBackgroundSelector({
 }) {
   const { t } = useTranslation(["game-misc", "common"]);
   const [stageId, setStageId] = React.useState<StageId>(stageIds[0]);
-  const [selectedMode, setSelectedMode] = React.useState<ModeShort>("SZ");
+  const [selectedMode, setSelectedMode] = React.useState<ModeShort>("CB");
 
   return (
     <div className="plans__top-section">

--- a/app/components/Planner.tsx
+++ b/app/components/Planner.tsx
@@ -134,7 +134,7 @@ export default function Planner() {
       });
 
       // Clam Blitz: add clams. Proof-of-concept for Scorched Gorge
-      if (modeShort === "CB") {
+      if (modeShort === "CB" && stageId === 0) {
         for (const clamPoint of scorchedGorgeClams.clam_points) {
           if (!clamPoint) continue;
 


### PR DESCRIPTION
# This is a WIP/Proof of Concept! DO NOT MERGE

Planner: added some proof-of-concept for rendering images for certain modes (Clam Blitz for example)

Generally speaking, we can define a data structure for a particular map/mode combination. Then if we find a data structure for a particular map/mode combination, do some extra image rendering.

The data structure can store all sorts of parameters (e.g. for Clam Blitz, we can store the clam locations, as well as some other asset info).

Results look something like this: 
![image](https://user-images.githubusercontent.com/15804376/203661505-16adfa72-df97-483c-88ca-eb27e1821e10.png)
