### PR TITLE
Ability chunk calculation now properly takes Ability Doubler into account

### DIFF
--- a/app/modules/analyzer/abilityChunksCalc.test.ts
+++ b/app/modules/analyzer/abilityChunksCalc.test.ts
@@ -39,6 +39,19 @@ GetAbilityChunksMapAsArray("Empty build results in an empty array", () => {
   assert.equal(abilityChunksArray, [], "Ability chunks array is not empty.");
 });
 
+GetAbilityChunksMapAsArray("Build ignores Ability Doubler", () => {
+  const buildWithOnlyAbilityDoubler = [
+    ["UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
+    ["AD", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
+    ["UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
+  ] as unknown as BuildAbilitiesTupleWithUnknown;
+
+  const abilityChunksArray = getAbilityChunksMapAsArray(
+    buildWithOnlyAbilityDoubler
+  );
+  assert.equal(abilityChunksArray, [], "Ability chunks array is not empty.");
+});
+
 GetAbilityChunksMapAsArray(
   "Main Ability stackable ability chunk calculation is correct",
   () => {

--- a/app/modules/analyzer/abilityChunksCalc.test.ts
+++ b/app/modules/analyzer/abilityChunksCalc.test.ts
@@ -39,18 +39,21 @@ GetAbilityChunksMapAsArray("Empty build results in an empty array", () => {
   assert.equal(abilityChunksArray, [], "Ability chunks array is not empty.");
 });
 
-GetAbilityChunksMapAsArray("Build ignores Ability Doubler", () => {
-  const buildWithOnlyAbilityDoubler = [
-    ["UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
-    ["AD", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
-    ["UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
-  ] as unknown as BuildAbilitiesTupleWithUnknown;
+GetAbilityChunksMapAsArray(
+  "Ability Doubler ability does not count towards Ability Chunks",
+  () => {
+    const buildWithOnlyAbilityDoubler = [
+      ["UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
+      ["AD", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
+      ["UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
+    ] as unknown as BuildAbilitiesTupleWithUnknown;
 
-  const abilityChunksArray = getAbilityChunksMapAsArray(
-    buildWithOnlyAbilityDoubler
-  );
-  assert.equal(abilityChunksArray, [], "Ability chunks array is not empty.");
-});
+    const abilityChunksArray = getAbilityChunksMapAsArray(
+      buildWithOnlyAbilityDoubler
+    );
+    assert.equal(abilityChunksArray, [], "Ability chunks array is not empty.");
+  }
+);
 
 GetAbilityChunksMapAsArray(
   "Main Ability stackable ability chunk calculation is correct",
@@ -139,6 +142,25 @@ GetAbilityChunksMapAsArray(
     ];
 
     const abilityChunksArray = getAbilityChunksMapAsArray(splatlingBuild);
+    validateAbilityChunksArray(abilityChunksArray, expectedOutput);
+  }
+);
+
+GetAbilityChunksMapAsArray(
+  "Sub abilities chunk calculation with Ability Doubler in Clothing slot is correct",
+  () => {
+    const build = [
+      ["UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
+      ["AD", "SSU", "SSU", "ISM"],
+      ["UNKNOWN", "UNKNOWN", "UNKNOWN", "UNKNOWN"],
+    ] as unknown as BuildAbilitiesTupleWithUnknown;
+
+    const expectedOutput = [
+      ["SSU", 9],
+      ["ISM", 3],
+    ];
+
+    const abilityChunksArray = getAbilityChunksMapAsArray(build);
     validateAbilityChunksArray(abilityChunksArray, expectedOutput);
   }
 );

--- a/app/modules/analyzer/abilityChunksCalc.ts
+++ b/app/modules/analyzer/abilityChunksCalc.ts
@@ -10,6 +10,8 @@ const MAIN_REQUIRED_ABILITY_CHUNKS_COUNT = 45;
 const PRIMARY_SLOT_ONLY_REQUIRED_ABILITY_CHUNKS_COUNT = 15;
 const SUB_REQUIRED_ABILITY_CHUNKS_COUNT = 10;
 
+export const ABILITIES_WITHOUT_CHUNKS = new Set(["UNKNOWN", "AD"]);
+
 // From a given build, create a map of <Ability, number>, then return it as an Array after sorting by value, descending.
 //    The data structure describes the number of Ability chunks required for any given build.
 export function getAbilityChunksMapAsArray(
@@ -34,7 +36,7 @@ function updateAbilityChunksMap(
 
     for (const [index, selectedAbility] of gear.entries()) {
       if (!selectedAbility) continue;
-      if (selectedAbility === "UNKNOWN") continue;
+      if (ABILITIES_WITHOUT_CHUNKS.has(selectedAbility)) continue;
 
       // Ability is in main slot
       if (index === 0) {

--- a/app/routes/analyzer.tsx
+++ b/app/routes/analyzer.tsx
@@ -48,7 +48,10 @@ import {
   specialWeaponImageUrl,
   subWeaponImageUrl,
 } from "~/utils/urls";
-import { ABILITIES_WITHOUT_CHUNKS, getAbilityChunksMapAsArray } from "~/modules/analyzer/abilityChunksCalc";
+import {
+  ABILITIES_WITHOUT_CHUNKS,
+  getAbilityChunksMapAsArray,
+} from "~/modules/analyzer/abilityChunksCalc";
 import clsx from "clsx";
 
 export const CURRENT_PATCH = "2.0";
@@ -144,7 +147,8 @@ export default function BuildAnalyzerPage() {
   // Handles edge case where a primary slot-only ability (e.g. Ninja Squid) is selected & the 'abilityPoints' count is still 0,
   //  and also fixes an edge case with Ability Doubler as the only ability in the build
   const showAbilityChunksRequired: boolean = build.some(
-    (gear) => gear.filter((ability) => !ABILITIES_WITHOUT_CHUNKS.has(ability)).length
+    (gear) =>
+      gear.filter((ability) => !ABILITIES_WITHOUT_CHUNKS.has(ability)).length
   );
 
   return (

--- a/app/routes/analyzer.tsx
+++ b/app/routes/analyzer.tsx
@@ -48,7 +48,7 @@ import {
   specialWeaponImageUrl,
   subWeaponImageUrl,
 } from "~/utils/urls";
-import { getAbilityChunksMapAsArray } from "~/modules/analyzer/abilityChunksCalc";
+import { ABILITIES_WITHOUT_CHUNKS, getAbilityChunksMapAsArray } from "~/modules/analyzer/abilityChunksCalc";
 import clsx from "clsx";
 
 export const CURRENT_PATCH = "2.0";
@@ -141,9 +141,10 @@ export default function BuildAnalyzerPage() {
     ),
   ].filter(Boolean);
 
-  // Handles edge case where a primary slot-only ability (e.g. Ninja Squid) is selected & the 'abilityPoints' count is still 0
+  // Handles edge case where a primary slot-only ability (e.g. Ninja Squid) is selected & the 'abilityPoints' count is still 0,
+  //  and also fixes an edge case with Ability Doubler as the only ability in the build
   const showAbilityChunksRequired: boolean = build.some(
-    (gear) => gear.filter((ability) => ability !== "UNKNOWN").length
+    (gear) => gear.filter((ability) => !ABILITIES_WITHOUT_CHUNKS.has(ability)).length
   );
 
   return (


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/1180

# Description of Changes

Ability chunk calculations now properly takes Ability Doubler into account
- Ability Doubler ability in of itself does not contribute towards ability chunk count.
- For the Clothing gear, if it has Ability Doubler, then the cost of adding a non-duplicate secondary (sub) ability only costs 3 ability chunks. Reference: https://splatoonwiki.org/wiki/Splatfest_Tee#Splatoon_3_2
- Build Analyzer also no longer shows Ability Doubler as an Ability Chunk entry, nor does it show the Ability Chunks accordion if Ability Doubler is the only selected ability in the build


# Unit Tests

I also added some unit tests to make sure that Ability Chunk calculations are behaving as intended when Ability Doubler is present on the Clothing gear.

Screenshot of passing unit tests for the ability chunks test file:

![image](https://user-images.githubusercontent.com/15804376/206062770-62f55dee-a56a-4d2e-9f4b-b74545f8f735.png)
