### PR TITLE
Ranked Modes checkboxes are now checked by default when making a new build

### DIFF
--- a/app/routes/u.$identifier/builds/new.tsx
+++ b/app/routes/u.$identifier/builds/new.tsx
@@ -254,7 +254,19 @@ function DescriptionTextarea() {
 }
 
 function ModeCheckboxes() {
+  const { buildToEdit } = useLoaderData<typeof loader>();
   const { t } = useTranslation("builds");
+
+  let currentBuildModes:
+    | typeof modesShort
+    | null
+    | undefined
+    | typeof rankedModesShort = buildToEdit?.modes;
+
+  // Use the Ranked Modes by default for brand new builds (so that the checkboxes can be checked by default)
+  if (!currentBuildModes) {
+    currentBuildModes = rankedModesShort;
+  }
 
   return (
     <div>
@@ -269,8 +281,8 @@ function ModeCheckboxes() {
               id={mode}
               name={mode}
               type="checkbox"
-              defaultChecked={rankedModesShort.some(
-                (rankedMode) => rankedMode === mode
+              defaultChecked={currentBuildModes?.some(
+                (currentMode) => currentMode == mode
               )}
               data-cy={`${mode}-checkbox`}
             />

--- a/app/routes/u.$identifier/builds/new.tsx
+++ b/app/routes/u.$identifier/builds/new.tsx
@@ -259,9 +259,9 @@ function ModeCheckboxes() {
 
   let currentBuildModes:
     | typeof modesShort
+    | typeof rankedModesShort
     | null
-    | undefined
-    | typeof rankedModesShort = buildToEdit?.modes;
+    | undefined = buildToEdit?.modes;
 
   // Use the Ranked Modes by default for brand new builds (so that the checkboxes can be checked by default)
   // See issue for more info: https://github.com/Sendouc/sendou.ink/issues/1150

--- a/app/routes/u.$identifier/builds/new.tsx
+++ b/app/routes/u.$identifier/builds/new.tsx
@@ -26,6 +26,7 @@ import {
   modesShort,
   shoesGearIds,
 } from "~/modules/in-game-lists";
+import { rankedModesShort } from "~/modules/in-game-lists/modes";
 import type {
   BuildAbilitiesTuple,
   BuildAbilitiesTupleWithUnknown,
@@ -253,7 +254,6 @@ function DescriptionTextarea() {
 }
 
 function ModeCheckboxes() {
-  const { buildToEdit } = useLoaderData<typeof loader>();
   const { t } = useTranslation("builds");
 
   return (
@@ -269,7 +269,9 @@ function ModeCheckboxes() {
               id={mode}
               name={mode}
               type="checkbox"
-              defaultChecked={buildToEdit?.modes?.includes(mode)}
+              defaultChecked={rankedModesShort.some(
+                (rankedMode) => rankedMode === mode
+              )}
               data-cy={`${mode}-checkbox`}
             />
           </div>

--- a/app/routes/u.$identifier/builds/new.tsx
+++ b/app/routes/u.$identifier/builds/new.tsx
@@ -264,6 +264,7 @@ function ModeCheckboxes() {
     | typeof rankedModesShort = buildToEdit?.modes;
 
   // Use the Ranked Modes by default for brand new builds (so that the checkboxes can be checked by default)
+  // See issue for more info: https://github.com/Sendouc/sendou.ink/issues/1150
   if (!currentBuildModes) {
     currentBuildModes = rankedModesShort;
   }


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/1150

# Description of Changes

Ranked Modes checkboxes are now checked by default when making a new build.

- Does not overwrite values for builds that already exist, i.e. builds that you are editing instead of attempting to create.