### PR TITLE
Implemented some dynamic background sizing & positioning calculations for the Map Planner

### DIFF
--- a/app/features/map-planner/components/Planner.tsx
+++ b/app/features/map-planner/components/Planner.tsx
@@ -33,6 +33,10 @@ import type { StageBackgroundStyle } from "../plans-types";
 export default function Planner() {
   const { t } = useTranslation(["common"]);
   const { i18n } = useTranslation();
+
+  // Natively available WindowSize hook: https://usehooks-ts.com/react-hook/use-window-size
+  const windowSize = useWindowSize();
+
   const appRef = React.useRef<TldrawApp>();
   const app = appRef.current!;
 
@@ -109,9 +113,6 @@ export default function Planner() {
     },
     [app, handleAddImage]
   );
-
-  // Natively available WindowSize hook: https://usehooks-ts.com/react-hook/use-window-size
-  const windowSize = useWindowSize();
 
   const handleAddBackgroundImage = React.useCallback(
     (urlArgs: {

--- a/app/features/map-planner/components/Planner.tsx
+++ b/app/features/map-planner/components/Planner.tsx
@@ -111,20 +111,26 @@ export default function Planner() {
       // Get 2 sets of [X, Y] point coordinates to bound the rectangle
       const pointTopLeftOfBgRectangleX = plannerBgParams.pointOffsetX;
       const pointTopLeftOfBgRectangleY = plannerBgParams.pointOffsetY;
+
+      // Subtract the size of the image here to correct the image spawn location at the right-most & bottom-most boundaries
       const pointBottomRightOfBgRectangleX =
         pointTopLeftOfBgRectangleX + plannerBgParams.bgWidth - imageSize;
       const pointBottomRightOfBgRectangleY =
         plannerBgParams.pointOffsetY + plannerBgParams.bgHeight - imageSize;
 
       // Derived values for image spawn rectangle
-      const imageSpawnBoxLeft = pointTopLeftOfBgRectangleX + (plannerBgParams.bgWidth * imageSpawnBoxOffsetFactorX);
+      const imageSpawnBoxLeft =
+        pointTopLeftOfBgRectangleX +
+        plannerBgParams.bgWidth * imageSpawnBoxOffsetFactorX;
       const imageSpawnBoxRight =
-      imageSpawnBoxSizeFactorX *
+        imageSpawnBoxSizeFactorX *
           (pointBottomRightOfBgRectangleX - pointTopLeftOfBgRectangleX) +
         imageSpawnBoxLeft;
-      const imageSpawnBoxTop = pointTopLeftOfBgRectangleY + (plannerBgParams.bgHeight * imageSpawnBoxOffsetFactorY);
+      const imageSpawnBoxTop =
+        pointTopLeftOfBgRectangleY +
+        plannerBgParams.bgHeight * imageSpawnBoxOffsetFactorY;
       const imageSpawnBoxBottom =
-      imageSpawnBoxSizeFactorY *
+        imageSpawnBoxSizeFactorY *
           (pointBottomRightOfBgRectangleY - pointTopLeftOfBgRectangleY) +
         imageSpawnBoxTop;
 

--- a/app/features/map-planner/components/Planner.tsx
+++ b/app/features/map-planner/components/Planner.tsx
@@ -8,7 +8,7 @@ import {
 } from "@tldraw/tldraw";
 import randomInt from "just-random-integer";
 import * as React from "react";
-import useWindowSize from "react-use/lib/useWindowSize";
+import { useWindowSize } from "react-use";
 import { useForceRefreshOnMount } from "~/hooks/useForceRefresh";
 import { useTranslation } from "~/hooks/useTranslation";
 import type { LanguageCode } from "~/modules/i18n";
@@ -121,7 +121,7 @@ export default function Planner() {
       style: StageBackgroundStyle;
     }) => {
       // Dynamic background size. See this issue for more info: https://github.com/Sendouc/sendou.ink/issues/1161
-      const bgSizeFactor = 0.7;
+      const bgSizeFactor = 0.85;
       const bgWidth = windowSize.width * bgSizeFactor;
       const bgHeight = windowSize.height * bgSizeFactor;
 

--- a/app/features/map-planner/components/Planner.tsx
+++ b/app/features/map-planner/components/Planner.tsx
@@ -125,12 +125,16 @@ export default function Planner() {
       const bgWidth = windowSize.width * bgSizeFactor;
       const bgHeight = windowSize.height * bgSizeFactor;
 
+      // Point offsets that move the image closer to the center of the window
+      const pointOffsetX = bgWidth * (1 - bgSizeFactor);
+      const pointOffsetY = 0.6 * (bgHeight * (1 - bgSizeFactor)); // Removes some dead space above the image
+
       app.resetDocument();
       handleAddImage({
         src: stageMinimapImageUrlWithEnding(urlArgs),
         size: [bgWidth, bgHeight],
         isLocked: true,
-        point: [bgWidth * (1 - bgSizeFactor), bgHeight * (1 - bgSizeFactor)], // Re-centers the image onto the canvas
+        point: [pointOffsetX, pointOffsetY],
       });
     },
     [app, handleAddImage, windowSize.height, windowSize.width]

--- a/app/features/map-planner/components/Planner.tsx
+++ b/app/features/map-planner/components/Planner.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tldraw/tldraw";
 import randomInt from "just-random-integer";
 import * as React from "react";
+import useWindowSize from "react-use/lib/useWindowSize";
 import { useForceRefreshOnMount } from "~/hooks/useForceRefresh";
 import { useTranslation } from "~/hooks/useTranslation";
 import type { LanguageCode } from "~/modules/i18n";
@@ -109,21 +110,29 @@ export default function Planner() {
     [app, handleAddImage]
   );
 
+  // Natively available WindowSize hook: https://usehooks-ts.com/react-hook/use-window-size
+  const windowSize = useWindowSize();
+
   const handleAddBackgroundImage = React.useCallback(
     (urlArgs: {
       stageId: StageId;
       mode: ModeShort;
       style: StageBackgroundStyle;
     }) => {
+      // Dynamic background size. See this issue for more info: https://github.com/Sendouc/sendou.ink/issues/1161
+      const bgSizeFactor = 0.7;
+      const bgWidth = windowSize.width * bgSizeFactor;
+      const bgHeight = windowSize.height * bgSizeFactor;
+
       app.resetDocument();
       handleAddImage({
         src: stageMinimapImageUrlWithEnding(urlArgs),
-        size: [1600, 900],
+        size: [bgWidth, bgHeight],
         isLocked: true,
-        point: [65, 20],
+        point: [bgWidth * (1 - bgSizeFactor), bgHeight * (1 - bgSizeFactor)], // Re-centers the image onto the canvas
       });
     },
-    [app, handleAddImage]
+    [app, handleAddImage, windowSize.height, windowSize.width]
   );
 
   return (

--- a/app/features/map-planner/components/Planner.tsx
+++ b/app/features/map-planner/components/Planner.tsx
@@ -101,42 +101,38 @@ export default function Planner() {
 
   const handleAddWeapon = React.useCallback(
     (src: string) => {
-      // Adjustable constants - we can move these later if needed
-      const imageSize = 45;
+      // Adjustable parameters for image spawning
+      const imageSizePx = 45;
       const imageSpawnBoxSizeFactorX = 0.15;
       const imageSpawnBoxSizeFactorY = 0.3;
       const imageSpawnBoxOffsetFactorX = 0;
       const imageSpawnBoxOffsetFactorY = 0.2;
 
-      // Get 2 sets of [X, Y] point coordinates to bound the rectangle
-      const pointTopLeftOfBgRectangleX = plannerBgParams.pointOffsetX;
-      const pointTopLeftOfBgRectangleY = plannerBgParams.pointOffsetY;
+      // Get positions of the background rectangle
+      const bgRectangleLeft = plannerBgParams.pointOffsetX;
+      const bgRectangleTop = plannerBgParams.pointOffsetY;
 
       // Subtract the size of the image here to correct the image spawn location at the right-most & bottom-most boundaries
-      const pointBottomRightOfBgRectangleX =
-        pointTopLeftOfBgRectangleX + plannerBgParams.bgWidth - imageSize;
-      const pointBottomRightOfBgRectangleY =
-        plannerBgParams.pointOffsetY + plannerBgParams.bgHeight - imageSize;
+      const bgRectangleRight =
+        bgRectangleLeft + plannerBgParams.bgWidth - imageSizePx;
+      const bgRectangleBottom =
+        plannerBgParams.pointOffsetY + plannerBgParams.bgHeight - imageSizePx;
 
-      // Derived values for image spawn rectangle
+      // Derived values for image spawn box
       const imageSpawnBoxLeft =
-        pointTopLeftOfBgRectangleX +
-        plannerBgParams.bgWidth * imageSpawnBoxOffsetFactorX;
+        bgRectangleLeft + plannerBgParams.bgWidth * imageSpawnBoxOffsetFactorX;
       const imageSpawnBoxRight =
-        imageSpawnBoxSizeFactorX *
-          (pointBottomRightOfBgRectangleX - pointTopLeftOfBgRectangleX) +
+        imageSpawnBoxSizeFactorX * (bgRectangleRight - bgRectangleLeft) +
         imageSpawnBoxLeft;
       const imageSpawnBoxTop =
-        pointTopLeftOfBgRectangleY +
-        plannerBgParams.bgHeight * imageSpawnBoxOffsetFactorY;
+        bgRectangleTop + plannerBgParams.bgHeight * imageSpawnBoxOffsetFactorY;
       const imageSpawnBoxBottom =
-        imageSpawnBoxSizeFactorY *
-          (pointBottomRightOfBgRectangleY - pointTopLeftOfBgRectangleY) +
+        imageSpawnBoxSizeFactorY * (bgRectangleBottom - bgRectangleTop) +
         imageSpawnBoxTop;
 
       handleAddImage({
         src,
-        size: [45, 45],
+        size: [imageSizePx, imageSizePx],
         isLocked: false,
         point: [
           randomInt(imageSpawnBoxLeft, imageSpawnBoxRight),

--- a/app/hooks/usePlannerBg.ts
+++ b/app/hooks/usePlannerBg.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect } from "react";
+import { useWindowSize } from "react-use";
+
+type PlannerBgParams = {
+  bgWidth: number;
+  bgHeight: number;
+  pointOffsetX: number;
+  pointOffsetY: number;
+};
+
+// Dynamic background size. See this issue for more info: https://github.com/Sendouc/sendou.ink/issues/1161
+const bgSizeFactor = 0.80;
+
+export function usePlannerBg() {
+  const [plannerBgParams, setPlannerBgParams] = useState({});
+
+  // Natively available WindowSize hook: https://usehooks-ts.com/react-hook/use-window-size
+  const windowSize = useWindowSize();
+
+  useEffect(() => {
+    const bgWidth = windowSize.width * bgSizeFactor;
+    const bgHeight = windowSize.height * bgSizeFactor;
+
+    // Point offsets that move the image closer to the center of the window
+    const pointOffsetX = bgWidth * (1 - bgSizeFactor);
+    const pointOffsetY = 0.6 * (bgHeight * (1 - bgSizeFactor)); // Removes some dead space above the image
+
+    setPlannerBgParams({
+      bgWidth, bgHeight, pointOffsetX, pointOffsetY
+    });
+  }, [windowSize.width, windowSize.height]);
+
+  return plannerBgParams as PlannerBgParams;
+}

--- a/app/hooks/usePlannerBg.ts
+++ b/app/hooks/usePlannerBg.ts
@@ -12,7 +12,12 @@ type PlannerBgParams = {
 const bgSizeFactor = 0.8;
 
 export function usePlannerBg() {
-  const [plannerBgParams, setPlannerBgParams] = useState({});
+  const [plannerBgParams, setPlannerBgParams] = useState<PlannerBgParams>({
+    bgWidth: 1200,
+    bgHeight: 800,
+    pointOffsetX: 240,
+    pointOffsetY: 96,
+  });
 
   // Natively available WindowSize hook: https://usehooks-ts.com/react-hook/use-window-size
   const windowSize = useWindowSize();
@@ -33,5 +38,5 @@ export function usePlannerBg() {
     });
   }, [windowSize.width, windowSize.height]);
 
-  return plannerBgParams as PlannerBgParams;
+  return plannerBgParams;
 }

--- a/app/hooks/usePlannerBg.ts
+++ b/app/hooks/usePlannerBg.ts
@@ -9,7 +9,7 @@ type PlannerBgParams = {
 };
 
 // Dynamic background size. See this issue for more info: https://github.com/Sendouc/sendou.ink/issues/1161
-const bgSizeFactor = 0.80;
+const bgSizeFactor = 0.8;
 
 export function usePlannerBg() {
   const [plannerBgParams, setPlannerBgParams] = useState({});
@@ -26,7 +26,10 @@ export function usePlannerBg() {
     const pointOffsetY = 0.6 * (bgHeight * (1 - bgSizeFactor)); // Removes some dead space above the image
 
     setPlannerBgParams({
-      bgWidth, bgHeight, pointOffsetX, pointOffsetY
+      bgWidth,
+      bgHeight,
+      pointOffsetX,
+      pointOffsetY,
     });
   }, [windowSize.width, windowSize.height]);
 

--- a/app/routes/contributions.tsx
+++ b/app/routes/contributions.tsx
@@ -5,6 +5,7 @@ import { useSetTitle } from "~/hooks/useSetTitle";
 import { languages } from "~/modules/i18n";
 import { makeTitle } from "~/utils/strings";
 import {
+  ANTARISKA_TWITTER,
   BORZOIC_TWITTER,
   GITHUB_CONTRIBUTORS_URL,
   LEAN_TWITTER,
@@ -114,6 +115,12 @@ export default function ContributionsPage() {
             yaga
           </a>{" "}
           - {t("contributions:yaga")}
+        </li>
+        <li>
+          <a href={ANTARISKA_TWITTER} target="_blank" rel="noreferrer">
+            Antariska
+          </a>{" "}
+          - {t("contributions:antariska")}
         </li>
         {TRANSLATORS.map(({ translators, language }) => (
           <li key={language}>

--- a/app/utils/urls.ts
+++ b/app/utils/urls.ts
@@ -42,6 +42,7 @@ export const BORZOIC_TWITTER = "https://twitter.com/borzoic_";
 export const LEAN_TWITTER = "https://twitter.com/LeanYoshi";
 export const UBERU_TWITTER = "https://twitter.com/uberu5";
 export const YAGA_TWITTER = "https://twitter.com/a_bog_hag";
+export const ANTARISKA_TWITTER = "https://twitter.com/antariska_spl";
 export const ipLabsMaps = (pool: string) =>
   `https://maps.iplabs.ink/?3&pool=${pool}`;
 

--- a/public/locales/en/contributions.json
+++ b/public/locales/en/contributions.json
@@ -5,5 +5,6 @@
   "borzoic": "Made badges, icons and front page art",
   "uberu": "Drew mini Judd holding heart emoji",
   "yaga": "Provided sub and special weapon icons",
+  "antariska": "Map planner background images",
   "translation": "Translation"
 }


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/1161

# Description

Implemented some dynamic background sizing & positioning calculations for the Map Planner.

This won't work well on mobile in portrait mode, since the user won't be able to access most of the controls (honestly, a user should not be attempting to use the feature in portrait mode anyway because it's impractical). It will work fine on landscape without any kind of min-sizing (as mentioned in the original issue).

# Screenshots and Examples

- 24" monitor, full screen (1920 x 1080):

![image](https://user-images.githubusercontent.com/15804376/210120244-40267c95-175d-455f-8526-b62405801694.png)

- 27" monitor, full screen (2560 x 1440):

![image](https://user-images.githubusercontent.com/15804376/210120250-d51f08b0-4701-494f-8bab-3574a7aff721.png)

- Pixel 5 in Landscape Mode (851 x 393):

![image](https://user-images.githubusercontent.com/15804376/210120256-10f3c62b-ab17-43db-9a57-a9f78c77a920.png)

- iPad Mini in Portrait Mode (768 x 1024):

![image](https://user-images.githubusercontent.com/15804376/210120255-cb5ed50b-f5cd-49a4-92b6-5d83f054106a.png)
