### PR TITLE
Corrected Danish translation in analyzer.json

### DIFF
--- a/public/locales/da/analyzer.json
+++ b/public/locales/da/analyzer.json
@@ -7,7 +7,7 @@
   "stat.category.main": "Hovedvåben",
   "stat.category.sub": "Sekundærvåben",
   "stat.category.special": "Special-våben",
-  "stat.category.subDef": "Forsvar mod sekundære våpen",
+  "stat.category.subDef": "Forsvar mod sekundære våben",
   "stat.category.actionsPerInkTank": "Handlinger per blæktank",
   "stat.category.damage": "Skade",
   "stat.category.movement": "Bevægelighed/Mobilitet",


### PR DESCRIPTION
Fixed misspeling of the following line in the Danish analyser.json file
-   "stat.category.subDef" #fixed a missspelling of "våben"