### PR TITLE
Fixed long trailing decimals from displaying for Special Weapon ink consumption stats

### DIFF
--- a/app/features/build-analyzer/core/stats.ts
+++ b/app/features/build-analyzer/core/stats.ts
@@ -1313,8 +1313,10 @@ function specialHookInkConsumptionPercentage(
   });
 
   return {
-    baseValue: roundToNDecimalPlaces(baseEffect * 100) / ZIPCASTER_INKTANK_SIZE,
-    value: roundToNDecimalPlaces(effect * 100) / ZIPCASTER_INKTANK_SIZE,
+    baseValue: roundToNDecimalPlaces(
+      (baseEffect * 100) / ZIPCASTER_INKTANK_SIZE
+    ),
+    value: roundToNDecimalPlaces((effect * 100) / ZIPCASTER_INKTANK_SIZE),
     modifiedBy: SPECIAL_HOOK_INK_CONSUMPTION_PERCENTAGE_KEY,
   };
 }
@@ -1342,8 +1344,10 @@ function specialInkConsumptionPerSecondPercentage(
   });
 
   return {
-    baseValue: roundToNDecimalPlaces(baseEffect * 100) / ZIPCASTER_INKTANK_SIZE,
-    value: roundToNDecimalPlaces(effect * 100) / ZIPCASTER_INKTANK_SIZE,
+    baseValue: roundToNDecimalPlaces(
+      (baseEffect * 100) / ZIPCASTER_INKTANK_SIZE
+    ),
+    value: roundToNDecimalPlaces((effect * 100) / ZIPCASTER_INKTANK_SIZE),
     modifiedBy: SPECIAL_INK_CONSUMPTION_PER_SECOND_PERCENTAGE_KEY,
   };
 }


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/1211

# Description

Fixed long trailing decimals from displaying for Special Weapon ink consumption stats.

All I did was include the entire mathematical expression in the `roundToNDecimalPlaces()` function that already existed.