### PR TITLE
Fix Drop Roller AP: 30 AP per ability

### DIFF
--- a/app/features/build-analyzer/core/specialEffects.test.ts
+++ b/app/features/build-analyzer/core/specialEffects.test.ts
@@ -69,7 +69,7 @@ ApplySpecialEffects("Applies many effects", () => {
     ldeIntensity: 0,
   });
 
-  assert.equal(aps.get("SSU"), 21);
+  assert.equal(aps.get("SSU"), 41);
 });
 
 ApplySpecialEffects("Applies LDE", () => {

--- a/app/features/build-analyzer/core/specialEffects.ts
+++ b/app/features/build-analyzer/core/specialEffects.ts
@@ -7,15 +7,15 @@ export const SPECIAL_EFFECTS = [
     values: [
       {
         type: "SSU",
-        ap: 10,
+        ap: 30,
       },
       {
         type: "RSU",
-        ap: 10,
+        ap: 30,
       },
       {
         type: "RES",
-        ap: 10,
+        ap: 30,
       },
     ],
   },


### PR DESCRIPTION
Change DR to give 30 AP per ability: See #1265 

Note that in my testing, DR *does* stack with normal abilities unlike Tacticooler (tested by running >30 AP of ink res alongside DR; as soon as the DR runs out you take ink damage, meaning that it does stack and doesn't simply raise it to 30 if it is less than that)