### PR TITLE
Fixed copyright note so that it does not overlap other UI elements horizontally at high zoom levels

### DIFF
--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -100,10 +100,14 @@ export function Footer({
       ) : null}
       <PlaywireBadge />
       <div className="layout__copyright-note">
-        sendou.ink © Copyright of Sendou and contributors 2019-{currentYear}.
-        Original content & source code is licensed under the GPL-3.0 license.
-        Splatoon is trademark & © of Nintendo 2014-{currentYear}. Sendou.ink is
-        not affiliated with Nintendo.
+        <p>
+          sendou.ink © Copyright of Sendou and contributors 2019-{currentYear}.
+          Original content & source code is licensed under the GPL-3.0 license.
+        </p>
+        <p>
+          Splatoon is trademark & © of Nintendo 2014-{currentYear}. sendou.ink
+          is not affiliated with Nintendo.
+        </p>
       </div>
     </footer>
   );

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -222,6 +222,8 @@
 }
 
 .layout__copyright-note {
+  display: flex;
+  flex-direction: column;
   color: var(--text-lighter);
   font-size: var(--fonts-xxs);
   text-align: center;


### PR DESCRIPTION
# Linked Issue

https://github.com/Sendouc/sendou.ink/issues/1276

# Description

Fixed copyright note so that it does not overlap other UI elements horizontally at high zoom levels (200% or higher).

Screenshot of the copyright notice after the change (at 200% zoom level):

![image](https://user-images.githubusercontent.com/15804376/221378975-4d45e090-a090-49a4-8a8d-3722d133a53a.png)


