### PR TITLE
Round sub velocity to thousandths place, fix bug in round function (Fixes #1348)

### DIFF
--- a/app/features/build-analyzer/core/stats.ts
+++ b/app/features/build-analyzer/core/stats.ts
@@ -1040,7 +1040,7 @@ const SUB_WEAPON_STATS = [
   {
     analyzedBuildKey: "subVelocity",
     abilityValuesKey: "SpawnSpeedZSpecUp",
-    type: "NO_CHANGE",
+    type: "SUB_VELOCITY",
   },
   {
     analyzedBuildKey: "subFirstPhaseDuration",
@@ -1092,6 +1092,8 @@ export function subStats(
       switch (type) {
         case "NO_CHANGE":
           return roundToNDecimalPlaces(effect);
+        case "SUB_VELOCITY":
+          return roundToNDecimalPlaces(effect, 3);
         case "HP":
           return roundToNDecimalPlaces(hpDivided(effect), 1);
         case "TIME":

--- a/app/utils/number.ts
+++ b/app/utils/number.ts
@@ -1,5 +1,5 @@
 export function roundToNDecimalPlaces(num: number, n = 2) {
-  return Number((Math.round(num * (10 ** n)) / (10 ** n)).toFixed(n));
+  return Number((Math.round(num * 10 ** n) / 10 ** n).toFixed(n));
 }
 
 export function cutToNDecimalPlaces(num: number, n = 2) {

--- a/app/utils/number.ts
+++ b/app/utils/number.ts
@@ -1,5 +1,5 @@
 export function roundToNDecimalPlaces(num: number, n = 2) {
-  return Number((Math.round(num * 100) / 100).toFixed(n));
+  return Number((Math.round(num * (10 ** n)) / (10 ** n)).toFixed(n));
 }
 
 export function cutToNDecimalPlaces(num: number, n = 2) {


### PR DESCRIPTION
Adjusts stats.ts and creates a new case for ability type, "SUB_VELOCITY", which would allow for separate processing in the future and keeps me from accidentally changing other values.

Fixes a bug in the roundToNDecimalPlaces routine in number.ts, where the previous implementation had a hard coded 2 decimal cutoff from the use of 100 instead of 10**n.

First time doing a pull request or using this javascript framework, so feel free to offer guidance or feedback.