### PR TITLE
Refactor: Remix V2 `meta`

### DIFF
--- a/app/features/build-analyzer/routes/analyzer.tsx
+++ b/app/features/build-analyzer/routes/analyzer.tsx
@@ -1,4 +1,4 @@
-import { type LinksFunction, type MetaFunction } from "@remix-run/node";
+import { type LinksFunction, type V2_MetaFunction } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
 import { Link } from "@remix-run/react";
 import * as React from "react";
@@ -68,11 +68,14 @@ import { atOrError } from "~/utils/arrays";
 
 export const CURRENT_PATCH = "3.1";
 
-export const meta: MetaFunction = () => {
-  return {
-    title: makeTitle("Build Analyzer"),
-    description: "Detailed stats for any weapon and build in Splatoon 3.",
-  };
+export const meta: V2_MetaFunction = () => {
+  return [
+    { title: makeTitle("Build Analyzer") },
+    {
+      name: "description",
+      content: "Detailed stats for any weapon and build in Splatoon 3.",
+    },
+  ];
 };
 
 export const links: LinksFunction = () => {

--- a/app/features/build-stats/routes/builds.$slug.popular.tsx
+++ b/app/features/build-stats/routes/builds.$slug.popular.tsx
@@ -1,4 +1,8 @@
-import type { LoaderArgs, MetaFunction, SerializeFrom } from "@remix-run/node";
+import type {
+  LoaderArgs,
+  V2_MetaFunction,
+  SerializeFrom,
+} from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { cachified } from "cachified";
 import clsx from "clsx";
@@ -20,14 +24,12 @@ import { abilitiesByWeaponId } from "../queries/abilitiesByWeaponId.server";
 import { cache, ttl } from "~/utils/cache.server";
 import { ONE_HOUR_IN_MS } from "~/constants";
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: data.meta.title,
-  };
+  return [{ title: data.meta.title }];
 };
 
 export const handle: SendouRouteHandle = {

--- a/app/features/build-stats/routes/builds.$slug.stats.tsx
+++ b/app/features/build-stats/routes/builds.$slug.stats.tsx
@@ -1,8 +1,8 @@
 import type {
   LinksFunction,
   LoaderArgs,
-  SerializeFrom,
   V2_MetaFunction,
+  SerializeFrom,
 } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { Main } from "~/components/Main";

--- a/app/features/build-stats/routes/builds.$slug.stats.tsx
+++ b/app/features/build-stats/routes/builds.$slug.stats.tsx
@@ -1,8 +1,8 @@
 import type {
   LinksFunction,
   LoaderArgs,
-  MetaFunction,
   SerializeFrom,
+  V2_MetaFunction,
 } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { Main } from "~/components/Main";
@@ -26,14 +26,12 @@ import { makeTitle } from "~/utils/strings";
 import { cache, ttl } from "~/utils/cache.server";
 import { cachified } from "cachified";
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: data.meta.title,
-  };
+  return [{ title: data.meta.title }];
 };
 
 export const links: LinksFunction = () => {

--- a/app/features/info/routes/privacy-policy.tsx
+++ b/app/features/info/routes/privacy-policy.tsx
@@ -1,11 +1,9 @@
-import type { MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/node";
 import { Main } from "~/components/Main";
 import { makeTitle } from "~/utils/strings";
 
-export const meta: MetaFunction = () => {
-  return {
-    title: makeTitle("Privacy Policy"),
-  };
+export const meta: V2_MetaFunction = () => {
+  return [{ title: makeTitle("Privacy Policy") }];
 };
 
 export default function PrivacyPolicyPage() {

--- a/app/features/info/routes/support.tsx
+++ b/app/features/info/routes/support.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import type { LinksFunction, V2_MetaFunction } from "@remix-run/node";
 import { Main } from "~/components/Main";
 import styles from "../support.css";
 import * as React from "react";
@@ -15,10 +15,8 @@ import { Trans } from "react-i18next";
 import { makeTitle } from "~/utils/strings";
 import { useSetTitle } from "~/hooks/useSetTitle";
 
-export const meta: MetaFunction = () => {
-  return {
-    title: makeTitle("Support"),
-  };
+export const meta: V2_MetaFunction = () => {
+  return [{ title: makeTitle("Support") }];
 };
 
 export const links: LinksFunction = () => {

--- a/app/features/map-planner/routes/plans.tsx
+++ b/app/features/map-planner/routes/plans.tsx
@@ -1,5 +1,5 @@
 import { lazy } from "react";
-import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import type { LinksFunction, V2_MetaFunction } from "@remix-run/node";
 import styles from "../plans.css";
 import type { SendouRouteHandle } from "~/utils/remix";
 import { useIsMounted } from "~/hooks/useIsMounted";
@@ -8,12 +8,15 @@ import { makeTitle } from "~/utils/strings";
 import { useTranslation } from "~/hooks/useTranslation";
 import { useSetTitle } from "~/hooks/useSetTitle";
 
-export const meta: MetaFunction = () => {
-  return {
-    title: makeTitle("Planner"),
-    description:
-      "Make the perfect Splatoon 3 battle plans by drawing on maps and adding weapon images",
-  };
+export const meta: V2_MetaFunction = () => {
+  return [
+    { title: makeTitle("Planner") },
+    {
+      name: "description",
+      content:
+        "Make the perfect Splatoon 3 battle plans by drawing on maps and adding weapon images",
+    },
+  ];
 };
 
 export const handle: SendouRouteHandle = {

--- a/app/features/team/routes/t.$customUrl.edit.tsx
+++ b/app/features/team/routes/t.$customUrl.edit.tsx
@@ -1,6 +1,6 @@
 import type {
   LinksFunction,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import {
@@ -47,16 +47,14 @@ export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
 
-export const meta: MetaFunction = ({
+export const meta: V2_MetaFunction = ({
   data,
 }: {
   data: SerializeFrom<typeof loader>;
 }) => {
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: makeTitle(data.team.name),
-  };
+  return [{ title: makeTitle(data.team.name) }];
 };
 
 export const handle: SendouRouteHandle = {

--- a/app/features/team/routes/t.$customUrl.roster.tsx
+++ b/app/features/team/routes/t.$customUrl.roster.tsx
@@ -1,6 +1,6 @@
 import type {
   LinksFunction,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import {
@@ -47,16 +47,14 @@ export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
 
-export const meta: MetaFunction = ({
+export const meta: V2_MetaFunction = ({
   data,
 }: {
   data: SerializeFrom<typeof loader>;
 }) => {
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: makeTitle(data.team.name),
-  };
+  return [{ title: makeTitle(data.team.name) }];
 };
 
 export const action: ActionFunction = async ({ request, params }) => {

--- a/app/features/team/routes/t.$customUrl.tsx
+++ b/app/features/team/routes/t.$customUrl.tsx
@@ -2,7 +2,7 @@ import type {
   ActionFunction,
   LinksFunction,
   LoaderArgs,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
@@ -48,17 +48,17 @@ import {
 } from "../team-utils";
 import styles from "../team.css";
 
-export const meta: MetaFunction = ({
+export const meta: V2_MetaFunction = ({
   data,
 }: {
   data: SerializeFrom<typeof loader>;
 }) => {
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: makeTitle(data.team.name),
-    description: data.team.bio,
-  };
+  return [
+    { title: makeTitle(data.team.name) },
+    { name: "description", content: data.team.bio },
+  ];
 };
 
 export const links: LinksFunction = () => {

--- a/app/features/team/routes/t.tsx
+++ b/app/features/team/routes/t.tsx
@@ -2,7 +2,7 @@ import type {
   ActionFunction,
   LinksFunction,
   LoaderArgs,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
@@ -42,16 +42,14 @@ import { TEAM } from "../team-constants";
 import { createTeamSchema } from "../team-schemas.server";
 import styles from "../team.css";
 
-export const meta: MetaFunction = ({
+export const meta: V2_MetaFunction = ({
   data,
 }: {
   data: SerializeFrom<typeof loader>;
 }) => {
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: data.title,
-  };
+  return [{ title: data.title }];
 };
 
 export const links: LinksFunction = () => {

--- a/app/features/top-search/routes/xsearch.player.$id.tsx
+++ b/app/features/top-search/routes/xsearch.player.$id.tsx
@@ -1,7 +1,7 @@
 import type {
   LinksFunction,
   LoaderArgs,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
@@ -20,17 +20,18 @@ export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: data.title,
-    description: `Splatoon 3 X Battle for the player ${
-      data.placements[0]!.name
-    }`,
-  };
+  return [
+    { title: data.title },
+    {
+      name: "description",
+      content: `Splatoon 3 X Battle for the player ${data.placements[0]!.name}`,
+    },
+  ];
 };
 
 export const loader = async ({ params, request }: LoaderArgs) => {

--- a/app/features/top-search/routes/xsearch.tsx
+++ b/app/features/top-search/routes/xsearch.tsx
@@ -1,7 +1,7 @@
 import type {
   LinksFunction,
   LoaderArgs,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import { useLoaderData, useSearchParams } from "@remix-run/react";
@@ -24,15 +24,15 @@ export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: data.title,
-    description: "Splatoon 3 X Battle results",
-  };
+  return [
+    { title: data.title },
+    { name: "description", content: "Splatoon 3 X Battle results" },
+  ];
 };
 
 export const loader = async ({ request }: LoaderArgs) => {

--- a/app/features/tournament/routes/to.$id.tsx
+++ b/app/features/tournament/routes/to.$id.tsx
@@ -1,7 +1,7 @@
 import type {
   LinksFunction,
   LoaderArgs,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import { Outlet, useLoaderData } from "@remix-run/react";
@@ -24,14 +24,12 @@ import { findTeamsByEventId } from "../queries/findTeamsByEventId.server";
 import { idFromParams } from "../tournament-utils";
 import styles from "../tournament.css";
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader>;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: makeTitle(data.event.name),
-  };
+  return [{ title: makeTitle(data.event.name) }];
 };
 
 export const links: LinksFunction = () => {

--- a/app/features/vods/routes/vods.$id.tsx
+++ b/app/features/vods/routes/vods.$id.tsx
@@ -1,7 +1,7 @@
 import type {
   LinksFunction,
   LoaderArgs,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
@@ -59,14 +59,12 @@ export const handle: SendouRouteHandle = {
   },
 };
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: makeTitle(data.vod.title),
-  };
+  return [{ title: makeTitle(data.vod.title) }];
 };
 
 export const loader = ({ params }: LoaderArgs) => {

--- a/app/features/vods/routes/vods.tsx
+++ b/app/features/vods/routes/vods.tsx
@@ -1,7 +1,7 @@
 import type {
   LinksFunction,
   LoaderArgs,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import { useLoaderData, useSearchParams } from "@remix-run/react";
@@ -33,14 +33,12 @@ export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: makeTitle(data.title),
-  };
+  return [{ title: makeTitle(data.title) }];
 };
 
 export const loader = async ({ request }: LoaderArgs) => {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -3,7 +3,7 @@ import {
   json,
   type LinksFunction,
   type LoaderFunction,
-  type MetaFunction,
+  type V2_MetaFunction,
 } from "@remix-run/node";
 import {
   Links,
@@ -61,17 +61,16 @@ export const links: LinksFunction = () => {
   ];
 };
 
-export const meta: MetaFunction = () => ({
-  charset: "utf-8",
-  title: "sendou.ink",
-  description:
-    "Competitive Splatoon Hub featuring gear planner, event calendar, builds by top players, and more!",
-  viewport: "initial-scale=1, viewport-fit=cover, user-scalable=no",
-  "apple-mobile-web-app-status-bar-style": "black-translucent",
-  "apple-mobile-web-app-capable": "yes",
-  "theme-color": "#010115",
-  "og:image": COMMON_PREVIEW_IMAGE,
-});
+export const meta: V2_MetaFunction = () => {
+  return [
+    { title: "sendou.ink" },
+    {
+      name: "description",
+      content:
+        "Competitive Splatoon Hub featuring gear planner, event calendar, builds by top players, and more!",
+    },
+  ];
+};
 
 export interface RootLoaderData {
   locale: string;
@@ -149,6 +148,18 @@ function Document({
   return (
     <html lang={locale} dir={i18n.dir()} className={htmlThemeClass}>
       <head>
+        <meta charSet="utf-8" />
+        <meta
+          name="viewport"
+          content="initial-scale=1, viewport-fit=cover, user-scalable=no"
+        />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="theme-color" content="#010115" />
+        <meta name="og:image" content={COMMON_PREVIEW_IMAGE} />
         <Meta />
         <Links />
         <ThemeHead />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -159,7 +159,7 @@ function Document({
         />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="theme-color" content="#010115" />
-        <meta name="og:image" content={COMMON_PREVIEW_IMAGE} />
+        <meta property="og:image" content={COMMON_PREVIEW_IMAGE} />
         <Meta />
         <Links />
         <ThemeHead />

--- a/app/routes/a.$slug.tsx
+++ b/app/routes/a.$slug.tsx
@@ -4,7 +4,7 @@ import {
   json,
   type SerializeFrom,
   type LoaderArgs,
-  type MetaFunction,
+  type V2_MetaFunction,
 } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import * as React from "react";
@@ -41,24 +41,24 @@ export const handle: SendouRouteHandle = {
   },
 };
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   invariant(args.params["slug"]);
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
   const description = data.content.trim().split("\n")[0];
 
-  return {
-    title: makeTitle(data.title),
-    "og:title": data.title,
-    description,
-    "og:description": description,
-    "twitter:card": "summary_large_image",
-    "og:image": articlePreviewUrl(args.params["slug"]),
-    "og:type": "article",
-    "og:site_name": "sendou.ink",
-  };
+  return [
+    { title: makeTitle(data.title) },
+    { name: "og:title", content: data.title },
+    { name: "description", content: description },
+    { name: "og:description", content: description },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "og:image", content: articlePreviewUrl(args.params["slug"]) },
+    { name: "og:type", content: "article" },
+    { name: "og:site_name", content: "sendou.ink" },
+  ];
 };
 
 export const loader = ({ params }: LoaderArgs) => {

--- a/app/routes/a.$slug.tsx
+++ b/app/routes/a.$slug.tsx
@@ -51,13 +51,13 @@ export const meta: V2_MetaFunction = (args) => {
 
   return [
     { title: makeTitle(data.title) },
-    { name: "og:title", content: data.title },
+    { property: "og:title", content: data.title },
     { name: "description", content: description },
-    { name: "og:description", content: description },
+    { property: "og:description", content: description },
     { name: "twitter:card", content: "summary_large_image" },
-    { name: "og:image", content: articlePreviewUrl(args.params["slug"]) },
-    { name: "og:type", content: "article" },
-    { name: "og:site_name", content: "sendou.ink" },
+    { property: "og:image", content: articlePreviewUrl(args.params["slug"]) },
+    { property: "og:type", content: "article" },
+    { property: "og:site_name", content: "sendou.ink" },
   ];
 };
 

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -1,7 +1,7 @@
 import type {
   ActionFunction,
   LoaderFunction,
-  MetaFunction,
+  V2_MetaFunction,
 } from "@remix-run/node";
 import { json, redirect } from "@remix-run/node";
 import { useFetcher, useLoaderData, useNavigation } from "@remix-run/react";
@@ -30,10 +30,8 @@ import { assertUnreachable } from "~/utils/types";
 import { impersonateUrl, SEED_URL, STOP_IMPERSONATING_URL } from "~/utils/urls";
 import { actualNumber } from "~/utils/zod";
 
-export const meta: MetaFunction = () => {
-  return {
-    title: makeTitle("Admin page"),
-  };
+export const meta: V2_MetaFunction = () => {
+  return [{ title: makeTitle("Admin page") }];
 };
 
 const adminActionSchema = z.union([

--- a/app/routes/builds/$slug.tsx
+++ b/app/routes/builds/$slug.tsx
@@ -1,6 +1,6 @@
 import {
   type LoaderArgs,
-  type MetaFunction,
+  type V2_MetaFunction,
   type SerializeFrom,
 } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
@@ -31,14 +31,12 @@ import { FireIcon } from "~/components/icons/Fire";
 import { cachified } from "cachified";
 import { cache, ttl } from "~/utils/cache.server";
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: data.title,
-  };
+  return [{ title: data.title }];
 };
 
 export const handle: SendouRouteHandle = {

--- a/app/routes/builds/index.tsx
+++ b/app/routes/builds/index.tsx
@@ -12,16 +12,19 @@ import {
 } from "~/utils/urls";
 import { type SendouRouteHandle } from "~/utils/remix";
 import styles from "~/styles/builds.css";
-import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import type { LinksFunction, V2_MetaFunction } from "@remix-run/node";
 import { Main } from "~/components/Main";
 import { makeTitle } from "~/utils/strings";
 import { useSetTitle } from "~/hooks/useSetTitle";
 
-export const meta: MetaFunction = () => {
-  return {
-    title: makeTitle("Builds"),
-    description: "View Splatoon 3 builds for all weapons by the best players",
-  };
+export const meta: V2_MetaFunction = () => {
+  return [
+    { title: makeTitle("Builds") },
+    {
+      name: "description",
+      content: "View Splatoon 3 builds for all weapons by the best players",
+    },
+  ];
 };
 
 export const handle: SendouRouteHandle = {

--- a/app/routes/calendar/$id/index.tsx
+++ b/app/routes/calendar/$id/index.tsx
@@ -4,7 +4,7 @@ import {
   redirect,
   type LinksFunction,
   type LoaderArgs,
-  type MetaFunction,
+  type V2_MetaFunction,
 } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { Link } from "@remix-run/react/dist/components";
@@ -81,15 +81,15 @@ export const links: LinksFunction = () => {
   ];
 };
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader>;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: data.title,
-    description: data.event.description,
-  };
+  return [
+    { title: data.title },
+    { name: "description", content: data.event.description },
+  ];
 };
 
 export const handle: SendouRouteHandle = {

--- a/app/routes/calendar/index.tsx
+++ b/app/routes/calendar/index.tsx
@@ -1,4 +1,8 @@
-import type { LoaderArgs, MetaFunction, SerializeFrom } from "@remix-run/node";
+import type {
+  LoaderArgs,
+  V2_MetaFunction,
+  SerializeFrom,
+} from "@remix-run/node";
 import { json, type LinksFunction } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import clsx from "clsx";
@@ -39,19 +43,22 @@ export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: data.title,
-    description: `${data.events.length} events happening during week ${
-      data.displayedWeek
-    } including ${joinListToNaturalString(
-      data.events.slice(0, 3).map((e) => e.name)
-    )}`,
-  };
+  return [
+    { title: data.title },
+    {
+      name: "description",
+      content: `${data.events.length} events happening during week ${
+        data.displayedWeek
+      } including ${joinListToNaturalString(
+        data.events.slice(0, 3).map((e) => e.name)
+      )}`,
+    },
+  ];
 };
 
 export const handle: SendouRouteHandle = {

--- a/app/routes/calendar/new.tsx
+++ b/app/routes/calendar/new.tsx
@@ -5,7 +5,7 @@ import {
   type ActionFunction,
   type LinksFunction,
   type LoaderArgs,
-  type MetaFunction,
+  type V2_MetaFunction,
 } from "@remix-run/node";
 import { Form, useLoaderData } from "@remix-run/react";
 import clsx from "clsx";
@@ -80,14 +80,12 @@ export const links: LinksFunction = () => {
   ];
 };
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: data.title,
-  };
+  return [{ title: data.title }];
 };
 
 const newCalendarEventActionSchema = z.object({

--- a/app/routes/contributions.tsx
+++ b/app/routes/contributions.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "@remix-run/node";
+import type { V2_MetaFunction } from "@remix-run/node";
 import { Trans } from "react-i18next";
 import { Main } from "~/components/Main";
 import { useSetTitle } from "~/hooks/useSetTitle";
@@ -18,10 +18,8 @@ import { type SendouRouteHandle } from "~/utils/remix";
 import { useTranslation } from "~/hooks/useTranslation";
 import * as React from "react";
 
-export const meta: MetaFunction = () => {
-  return {
-    title: makeTitle("Contributions"),
-  };
+export const meta: V2_MetaFunction = () => {
+  return [{ title: makeTitle("Contributions") }];
 };
 
 export const handle: SendouRouteHandle = {

--- a/app/routes/faq.tsx
+++ b/app/routes/faq.tsx
@@ -1,4 +1,4 @@
-import type { LinksFunction, MetaFunction } from "@remix-run/node";
+import type { LinksFunction, V2_MetaFunction } from "@remix-run/node";
 import { useTranslation } from "~/hooks/useTranslation";
 import { Main } from "~/components/Main";
 import { useSetTitle } from "~/hooks/useSetTitle";
@@ -8,11 +8,11 @@ import { type SendouRouteHandle } from "~/utils/remix";
 
 const AMOUNT_OF_QUESTIONS = 8;
 
-export const meta: MetaFunction = () => {
-  return {
-    title: makeTitle("FAQ"),
-    description: "Frequently asked questions",
-  };
+export const meta: V2_MetaFunction = () => {
+  return [
+    { title: makeTitle("FAQ") },
+    { name: "description", content: "Frequently asked questions" },
+  ];
 };
 
 export const links: LinksFunction = () => {

--- a/app/routes/maps.tsx
+++ b/app/routes/maps.tsx
@@ -1,7 +1,7 @@
 import type {
   LinksFunction,
   LoaderArgs,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
@@ -50,14 +50,12 @@ export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
 
-export const meta: MetaFunction = (args) => {
+export const meta: V2_MetaFunction = (args) => {
   const data = args.data as SerializeFrom<typeof loader> | null;
 
-  if (!data) return {};
+  if (!data) return [];
 
-  return {
-    title: data.title,
-  };
+  return [{ title: data.title }];
 };
 
 export const handle: SendouRouteHandle = {

--- a/app/routes/plus/suggestions.tsx
+++ b/app/routes/plus/suggestions.tsx
@@ -1,7 +1,7 @@
 import type {
   ActionFunction,
   LoaderFunction,
-  MetaFunction,
+  V2_MetaFunction,
 } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import type { ShouldRevalidateFunction } from "@remix-run/react";
@@ -37,11 +37,14 @@ import { PLUS_TIERS } from "~/constants";
 import { assertUnreachable } from "~/utils/types";
 import { getUserId } from "~/modules/auth/user.server";
 
-export const meta: MetaFunction = () => {
-  return {
-    title: makeTitle("Plus Server suggestions"),
-    description: "This month's suggestions for +1, +2 and +3.",
-  };
+export const meta: V2_MetaFunction = () => {
+  return [
+    { title: makeTitle("Plus Server suggestions") },
+    {
+      name: "description",
+      content: "This month's suggestions for +1, +2 and +3.",
+    },
+  ];
 };
 
 const suggestionActionSchema = z.union([

--- a/app/routes/plus/voting/index.tsx
+++ b/app/routes/plus/voting/index.tsx
@@ -1,7 +1,7 @@
 import type {
   ActionFunction,
   LoaderFunction,
-  MetaFunction,
+  V2_MetaFunction,
 } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { Form, useLoaderData } from "@remix-run/react";
@@ -30,10 +30,8 @@ import { assertType, assertUnreachable } from "~/utils/types";
 import { safeJSONParse } from "~/utils/zod";
 import { PlusSuggestionComments } from "../suggestions";
 
-export const meta: MetaFunction = () => {
-  return {
-    title: makeTitle("Plus Server voting"),
-  };
+export const meta: V2_MetaFunction = () => {
+  return [{ title: makeTitle("Plus Server voting") }];
 };
 
 const voteSchema = z.object({

--- a/app/routes/plus/voting/results.tsx
+++ b/app/routes/plus/voting/results.tsx
@@ -1,7 +1,7 @@
 import type {
   LinksFunction,
   LoaderFunction,
-  MetaFunction,
+  V2_MetaFunction,
 } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
@@ -22,13 +22,16 @@ export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
 
-export const meta: MetaFunction = () => {
+export const meta: V2_MetaFunction = () => {
   const { month, year } = lastCompletedVoting(new Date());
 
-  return {
-    title: makeTitle("Plus Server voting history"),
-    description: `Plus Server voting results for ${month + 1}/${year}`,
-  };
+  return [
+    { title: makeTitle("Plus Server voting history") },
+    {
+      name: "description",
+      content: `Plus Server voting results for ${month + 1}/${year}`,
+    },
+  ];
 };
 
 interface PlusVotingResultsLoaderData {

--- a/app/routes/u.$identifier.tsx
+++ b/app/routes/u.$identifier.tsx
@@ -1,7 +1,7 @@
 import type {
   LinksFunction,
   LoaderArgs,
-  MetaFunction,
+  V2_MetaFunction,
   SerializeFrom,
 } from "@remix-run/node";
 import { json } from "@remix-run/node";
@@ -36,12 +36,14 @@ export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
 
-export const meta: MetaFunction = ({ data }: { data: UserPageLoaderData }) => {
-  if (!data) return {};
+export const meta: V2_MetaFunction = ({
+  data,
+}: {
+  data: UserPageLoaderData;
+}) => {
+  if (!data) return [];
 
-  return {
-    title: makeTitle(discordFullName(data)),
-  };
+  return [{ title: makeTitle(discordFullName(data)) }];
 };
 
 export const handle: SendouRouteHandle = {

--- a/remix.config.js
+++ b/remix.config.js
@@ -58,4 +58,7 @@ module.exports = {
       );
     });
   },
+  future: {
+    v2_meta: true,
+  },
 };


### PR DESCRIPTION
Refactors #1343 

### Changes

1. Opt-in to the Remix V2 meta by adding

```javascript
  future: {
    v2_meta: true,
  },
```

to `remix.config.js`

2. Move some `meta` fields into HTML `<meta>` tags, as suggested in https://remix.run/docs/en/1.15.0/route/meta-v2#global-meta

3. Manually search for `MetaFunction` and change them to `V2_MetaFunction` (I actually have no idea if there's a smarter way to do this...)

### Breaking change

According to the official doc, in V1, parent routes' meta data will be merged into the children's (if conflicted then keep the children's). But in V2, Remix will only keep the deepest meta data. So as for now, if `root.tsx` contains some meta data that children's meta data doesn't include, these will be lost (actually, there's only one, which is the "description"). The change is shown below.

#### V1

![image](https://user-images.githubusercontent.com/99558412/234658217-9b76b204-a436-4088-abb1-6ff96ef0a31d.png)

#### V2 (missing "description")

![image](https://user-images.githubusercontent.com/99558412/234877458-dddd45c0-8163-47a0-a2d3-e59d22421a06.png)

It can be solved by adding `{ matches }` to the `V2_MetaFunction`, like this (code from the official doc):

```javascript
export const meta: V2_MetaFunction = ({ matches }) => {
  let parentMeta = matches
    .flatMap((match) => match.meta ?? [])
    .filter((meta) => !("title" in meta));
  return [...parentMeta, { title: "Projects" }];
};
```

In this way, we must explicitly filter every conflict field, which is quite difficult to maintain. And we have to add this to every V2_MetaFunction, which seems a bit messy. So I didn't do it.
