### PR TITLE
Fix: page scrolls to top when opening dialog

### DIFF
--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -449,6 +449,7 @@ dialog::backdrop {
   border: none;
   margin: auto 0;
 }
+
 /* stylelint-enable no-descending-specificity */
 
 .input-container > input:focus-within {
@@ -772,6 +773,7 @@ dialog::backdrop {
 
 .lock-scroll {
   overflow: hidden;
+  height: unset;
 }
 
 /* https://stackoverflow.com/questions/50917016/make-a-hidden-field-required/50917245#comment117565184_50917245 */

--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -345,7 +345,6 @@ dialog {
 dialog::backdrop {
   background: hsla(237deg 98% 1% / 70%);
 }
-
 @supports ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
   dialog::backdrop {
     -webkit-backdrop-filter: blur(7px) brightness(70%);

--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -345,6 +345,7 @@ dialog {
 dialog::backdrop {
   background: hsla(237deg 98% 1% / 70%);
 }
+
 @supports ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
   dialog::backdrop {
     -webkit-backdrop-filter: blur(7px) brightness(70%);
@@ -448,7 +449,6 @@ dialog::backdrop {
   border: none;
   margin: auto 0;
 }
-
 /* stylelint-enable no-descending-specificity */
 
 .input-container > input:focus-within {


### PR DESCRIPTION
Fixes #1411

After some searching, I was very lucky to find the easiest solution, which is described in this comment:

> PS Omitting the height: 100% effectively locks the scrolling at the current position without the jumping - on latest Chrome, at least. – [zerm](https://stackoverflow.com/users/359335/zerm)
 
https://stackoverflow.com/questions/3656592/how-to-programmatically-disable-page-scrolling-with-jquery

(I actually have no idea why it behaves like that...)

P.S. There's also a JavaScript solution but is not even close as neat: https://stackoverflow.com/questions/4770025/how-to-disable-scrolling-temporarily