### PR TITLE
Fixed #1407

### DIFF
--- a/app/routes/u.$identifier/results/index.tsx
+++ b/app/routes/u.$identifier/results/index.tsx
@@ -34,7 +34,7 @@ export default function UserResultsPage() {
       {showHighlightsSection && (
         <Section
           title={t("results.highlights")}
-          className="u__results-table-wrapper u__results-table-highlights stack md items-center"
+          className="u__results-table-wrapper u__results-table-highlights stack md"
         >
           {hasHighlights && (
             <UserResultsTable


### PR DESCRIPTION
First time creating a pull request, hope this is alright.

Single line fix, the style "items-center" was applied to the whole table, causing all the content to align to center, which caused overflow if it didnt fit the screen.

The style already gets applied to the individual list items, so removing it from the table caused no further issues.