### PR TITLE
Page layout change proposal

### DIFF
--- a/app/components/Main.tsx
+++ b/app/components/Main.tsx
@@ -1,9 +1,10 @@
-import { useCatch } from "@remix-run/react";
+import { useCatch, useLocation } from "@remix-run/react";
 import clsx from "clsx";
 import type * as React from "react";
 import { useMatches } from "react-router";
 import { useUser } from "~/modules/auth";
 import type { RootLoaderData } from "~/root";
+import { SideNav } from "app/components/layout/SideNav";
 
 export const Main = ({
   children,
@@ -25,28 +26,34 @@ export const Main = ({
   const user = useUser();
   const showLeaderboard = data?.publisherId && !user?.patronTier && !caught;
 
+  const location = useLocation();
+  const isFrontPage = location.pathname === "/";
+
   return (
-    <main
-      className={
-        classNameOverwrite
-          ? clsx(classNameOverwrite, {
-              "half-width": halfWidth,
-              "pt-8-forced": showLeaderboard,
-            })
-          : clsx(
-              "layout__main",
-              "main",
-              {
+    <div className="layout__main-container">
+      {!isFrontPage ? <SideNav /> : null}
+      <main
+        className={
+          classNameOverwrite
+            ? clsx(classNameOverwrite, {
                 "half-width": halfWidth,
-                bigger,
                 "pt-8-forced": showLeaderboard,
-              },
-              className,
-            )
-      }
-      style={style}
-    >
-      {children}
-    </main>
+              })
+            : clsx(
+                "layout__main",
+                "main",
+                {
+                  "half-width": halfWidth,
+                  bigger,
+                  "pt-8-forced": showLeaderboard,
+                },
+                className,
+              )
+        }
+        style={style}
+      >
+        {children}
+      </main>
+    </div>
   );
 };

--- a/app/components/layout/SideNav.tsx
+++ b/app/components/layout/SideNav.tsx
@@ -12,7 +12,7 @@ export function SideNav() {
       {navItems.map((item) => {
         return (
           <Link
-            to={item.url}
+            to={`/${item.url}`}
             key={item.name}
             prefetch={item.prefetch ? "render" : undefined}
           >

--- a/app/components/layout/index.tsx
+++ b/app/components/layout/index.tsx
@@ -5,7 +5,6 @@ import type { Breadcrumb, SendouRouteHandle } from "~/utils/remix";
 import { Footer } from "./Footer";
 import { useTranslation } from "~/hooks/useTranslation";
 import { Image } from "../Image";
-import { SideNav } from "./SideNav";
 import { UserItem } from "./UserItem";
 import { LanguageChanger } from "./LanguageChanger";
 import { ThemeChanger } from "./ThemeChanger";
@@ -110,7 +109,6 @@ export const Layout = React.memo(function Layout({
           {!isErrored ? <UserItem /> : null}
         </div>
       </header>
-      {!isFrontPage ? <SideNav /> : null}
       {showLeaderboard ? <MyRampUnit /> : null}
       {children}
       <Footer patrons={data?.patrons} />

--- a/app/routes/calendar/index.tsx
+++ b/app/routes/calendar/index.tsx
@@ -167,7 +167,7 @@ export default function CalendarPage() {
     : data.events;
 
   return (
-    <Main classNameOverwrite="stack lg layout__main">
+    <Main classNameOverwrite="stack lg main layout__main">
       <WeekLinks />
       <EventsToReport />
       <div className="stack md">

--- a/app/styles/calendar.css
+++ b/app/styles/calendar.css
@@ -104,8 +104,9 @@
 .calendar__event {
   display: flex;
   flex-direction: column;
-  padding-top: var(--s-4);
+  padding-top: var(--s-3);
   font-size: var(--fonts-lg);
+  padding-inline: var(--s-4);
 }
 
 .calendar__event + .calendar__event {

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -1,7 +1,8 @@
 .layout__container {
   display: flex;
-  height: 100%;
   flex-direction: column;
+  width: 100%;
+  min-height: 100vh;
 }
 
 .layout__breadcrumb-container {
@@ -36,9 +37,7 @@
 }
 
 .layout__header {
-  position: fixed;
   z-index: 501;
-  top: 0;
   display: flex;
   width: 100%;
   align-items: center;
@@ -50,6 +49,8 @@
   font-weight: bold;
   padding-block: var(--s-2);
   padding-inline: var(--s-4);
+  position: sticky;
+  top: 0;
 }
 
 .layout__avatar {
@@ -105,6 +106,11 @@
   width: 100%;
   max-width: 72rem;
   margin: 0 auto;
+}
+
+.layout__main-container {
+  display: flex;
+  flex-direction: row;
 }
 
 .layout__main {
@@ -244,18 +250,42 @@
 }
 
 .layout__side-nav {
-  --top-size: calc(var(--item-size) + 2 * var(--s-2));
-
-  position: fixed;
-  top: var(--top-size);
+  background: black;
   display: flex;
-  height: calc(100vh - var(--top-size));
   flex-direction: column;
-  justify-content: flex-start;
   gap: var(--s-6);
-  overflow-y: auto;
   padding-block: var(--s-3);
   padding-inline: var(--s-4);
+  width: fit-content;
+  -webkit-backdrop-filter: var(--backdrop-filter);
+  backdrop-filter: var(--backdrop-filter);
+  background-color: transparent;
+  overflow-y: auto;
+  direction: rtl;
+  max-height: calc(100vh - 47px);
+  position: sticky;
+  top: 47px;
+}
+
+.layout__side-nav::-webkit-scrollbar {
+  width: 4px;
+}
+
+.layout__side-nav::-webkit-scrollbar-track {
+  background-color: rgb(2, 1, 30);
+}
+
+.layout__side-nav::-webkit-scrollbar-corner {
+  background-color: rgb(2, 1, 30);
+}
+
+.layout__side-nav::-webkit-scrollbar-thumb {
+  background-color: rgb(83, 65, 91);
+  border-radius: 4px;
+}
+
+.layout__side-nav::-webkit-scrollbar-thumb:hover {
+  background-color: rgb(62, 49, 68);
 }
 
 .layout__side-nav-image-container {

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -264,6 +264,7 @@
   overflow-x: hidden;
   direction: rtl;
   position: sticky;
+
   /*
   Top pixel count needs to be the same as nav height
   Max height is calculated using the viewport height minus the nav height
@@ -273,7 +274,7 @@
   */
   top: 47px;
   max-height: calc(100vh - 47px);
-  scrollbar-color: rgb(83, 65, 91) transparent;
+  scrollbar-color: rgb(83 65 91) transparent;
   scrollbar-width: thin;
   scrollbar-gutter: stable;
 }
@@ -297,12 +298,12 @@ Firefox scrollbar styling is above in .layout__side-nav
 }
 
 .layout__side-nav::-webkit-scrollbar-thumb {
-  background-color: rgb(83, 65, 91);
+  background-color: rgb(83 65 91);
   border-radius: 4px;
 }
 
 .layout__side-nav::-webkit-scrollbar-thumb:hover {
-  background-color: rgb(62, 49, 68);
+  background-color: rgb(62 49 68);
 }
 
 .layout__side-nav-image-container {

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -115,7 +115,7 @@
 
 .layout__main {
   padding-block-end: var(--s-32);
-  padding-block-start: var(--s-16);
+  padding-block-start: var(--s-4);
 }
 
 .layout__log-in-button {
@@ -261,10 +261,18 @@
   backdrop-filter: var(--backdrop-filter);
   background-color: transparent;
   overflow-y: auto;
+  overflow-x: hidden;
   direction: rtl;
-  max-height: calc(100vh - 47px);
   position: sticky;
+  /*
+  Top pixel count needs to be the same as nav height
+  Max height is calculated using the viewport height minus the nav height
+  This is unfortunately needed to avoid the sidebar from overflowing the viewport or navbar
+  Without this, the sidebar would be cut off at the bottom or top or clip into it
+  Will return if a better solution is found that doesnt require a hard coded value
+  */
   top: 47px;
+  max-height: calc(100vh - 47px);
 }
 
 .layout__side-nav::-webkit-scrollbar {

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -273,7 +273,7 @@
   */
   top: 47px;
   max-height: calc(100vh - 47px);
-  scrollbar-color: rgb(83, 65, 91) rgb(2, 1, 30);
+  scrollbar-color: rgb(83, 65, 91) transparent;
   scrollbar-width: thin;
   scrollbar-gutter: stable;
 }
@@ -287,11 +287,13 @@ Firefox scrollbar styling is above in .layout__side-nav
 }
 
 .layout__side-nav::-webkit-scrollbar-track {
-  background-color: rgb(2, 1, 30);
+  background: black;
+  background-color: transparent;
 }
 
 .layout__side-nav::-webkit-scrollbar-corner {
-  background-color: rgb(2, 1, 30);
+  background: black;
+  background-color: transparent;
 }
 
 .layout__side-nav::-webkit-scrollbar-thumb {

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -273,8 +273,15 @@
   */
   top: 47px;
   max-height: calc(100vh - 47px);
+  scrollbar-color: rgb(83, 65, 91) rgb(2, 1, 30);
+  scrollbar-width: thin;
+  scrollbar-gutter: stable;
 }
 
+/*
+Works on literally every browser except Firefox 
+Firefox scrollbar styling is above in .layout__side-nav
+*/
 .layout__side-nav::-webkit-scrollbar {
   width: 4px;
 }


### PR DESCRIPTION
I noticed on the VODs page that the content clips into the sidebar before it reaches the breakpoint.

![opera_ntHC5It9FD](https://github.com/Sendouc/sendou.ink/assets/101019309/a4f47fe4-cf66-4009-b1dc-8a21d1f61373)

I was going to make a quick fix by adding some padding, but noticed the reason for this is that both navbar and sidebar do not take any actual space on the page due to having a fixed position.

By moving around some elements and changing them to be sticky its possible to have the same behavior while having the elements actually take up space.

This makes layouting easier and more consistent and avoids clipping. Both navbar and sidebar would also be more future proof to any changes since they can no longer mess with any page content.

It also has the added benefit of making the interaction with the footer a lot more natural!

![opera_55FEJnINem](https://github.com/Sendouc/sendou.ink/assets/101019309/4c38c53b-17ef-4924-b7ea-d0d9738d4ac9)

If you look at the main content div you can see that it now respects the sidebar and navbar

![Untitled](https://github.com/Sendouc/sendou.ink/assets/101019309/2ae2f025-3cc6-4e42-b2f7-adf5bd97ad0e)

I made the pull request a draft because in order to avoid clipping in the current layout, all pages have top paddings applied to them, which means I would have to go through every page and adjust the paddings to get the original look back, so I would like to get your thoughts on this first!