### PR TITLE
improve rtl handling in pagination and front

### DIFF
--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -3,6 +3,7 @@ import { Button } from "~/components/Button";
 import { ArrowLeftIcon } from "~/components/icons/ArrowLeft";
 import { ArrowRightIcon } from "~/components/icons/ArrowRight";
 import { nullFilledArray } from "~/utils/arrays";
+import { useTranslation } from "~/hooks/useTranslation";
 
 export function Pagination({
   currentPage,
@@ -17,10 +18,12 @@ export function Pagination({
   previousPage: () => void;
   setPage: (page: number) => void;
 }) {
+  const { i18n } = useTranslation();
+  var invertArrows = i18n.dir(i18n.language) === "rtl";
   return (
     <div className="stack sm horizontal items-center justify-center flex-wrap">
       <Button
-        icon={<ArrowLeftIcon />}
+        icon={invertArrows ? <ArrowRightIcon /> : <ArrowLeftIcon />}
         variant="outlined"
         disabled={currentPage === 1}
         onClick={previousPage}
@@ -39,7 +42,7 @@ export function Pagination({
         {currentPage}/{pagesCount}
       </div>
       <Button
-        icon={<ArrowRightIcon />}
+        icon={invertArrows ? <ArrowLeftIcon /> : <ArrowRightIcon />}
         variant="outlined"
         disabled={currentPage === pagesCount}
         onClick={nextPage}

--- a/app/styles/front.css
+++ b/app/styles/front.css
@@ -63,6 +63,7 @@
 }
 
 .front__drawings {
+  direction: ltr;
   display: grid;
   grid-template-columns: 1fr 1fr;
   margin-block-start: var(--s-8);


### PR DESCRIPTION
This closes issue #1513
It sets `icon` to the left arrow on the right button and vice-versa if the user language's direction is `rtl`, as we'd still expect the behavior of the buttons and pagination dots to reverse alongside the language.

Additionally, it styles the class `.front__drawings` to display in Left to Right no matter the direction of the user's language.