### PR TITLE
Added rtl utility class

### DIFF
--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -22,6 +22,7 @@ export function Pagination({
       <Button
         icon={<ArrowLeftIcon />}
         variant="outlined"
+        className="fix-rtl"
         disabled={currentPage === 1}
         onClick={previousPage}
         aria-label="Previous page"
@@ -41,6 +42,7 @@ export function Pagination({
       <Button
         icon={<ArrowRightIcon />}
         variant="outlined"
+        className="fix-rtl"
         disabled={currentPage === pagesCount}
         onClick={nextPage}
         aria-label="Next page"

--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -1291,6 +1291,10 @@ dialog::backdrop {
   margin-block-start: var(--s-0-5);
 }
 
+html[dir="rtl"] .fix-rtl {
+  transform: rotate(180deg);
+}
+
 .pagination__dot {
   width: 0.6rem;
   height: 0.6rem;


### PR DESCRIPTION
This fixes issue https://github.com/Sendouc/sendou.ink/issues/1513

Since you already applied the ``dir="rtl"`` attribute to the HTML element, we can use a CSS attribute selector to apply a style to a class only if that attribute is present.

This makes for a really simple and clean implementation. If any future RTL issues come up, you can just make your own utility class using the ``html[dir="rtl"]`` attribute selector.
