### PR TITLE
Add/Fix miscellaneous object damage/build analyzer data

### DIFF
--- a/app/features/build-analyzer/core/weapon-params.json
+++ b/app/features/build-analyzer/core/weapon-params.json
@@ -2319,7 +2319,17 @@
           "Low": 1,
           "Mid": 1.05
         }
-      }
+      },
+      "DistanceDamage": [
+        {
+          "Damage": 2200,
+          "Distance": 7
+        },
+        {
+          "Damage": 600,
+          "Distance": 12
+        }
+      ]
     },
     "19": {
       "overwrites": {

--- a/app/features/object-damage-calculator/calculator-constants.ts
+++ b/app/features/object-damage-calculator/calculator-constants.ts
@@ -10,6 +10,7 @@ export const DAMAGE_RECEIVERS = [
   "ShockSonar", // Wave Breaker
   "GreatBarrier_Barrier", // Big Bubbler Shield
   "GreatBarrier_WeakPoint", // Big Bubbler Weak Point
+  "BlowerInhale", // Ink Vac Inhale
   "Gachihoko_Barrier", // Rainmaker Shield
   "Wsb_Flag", // Squid Beakon
   "Wsb_Shield", // Splash Wall

--- a/app/features/object-damage-calculator/calculator-constants.ts
+++ b/app/features/object-damage-calculator/calculator-constants.ts
@@ -107,6 +107,7 @@ export const damagePriorities: Array<
   ["SPECIAL", [12], "SPECIAL_BULLET_MIN", "Chariot_Cannon"],
   ["SPECIAL", [12], "SPECIAL_BUMP", "Chariot_Body"],
   ["SPECIAL", [13], "BOMB_NORMAL", "Skewer"],
+  ["SPECIAL", [18], "BOMB_NORMAL", "Pogo"],
 ];
 
 export const damageTypesToCombine: Partial<

--- a/app/features/object-damage-calculator/core/object-dmg.json
+++ b/app/features/object-damage-calculator/core/object-dmg.json
@@ -1738,6 +1738,65 @@
       }
     ]
   },
+  "Pogo": {
+    "mainWeaponIds": [],
+    "subWeaponIds": [],
+    "specialWeaponIds": [18],
+    "rates": [
+      {
+        "target": "Bomb_TorpedoBullet",
+        "rate": 0.5
+      },
+      {
+        "target": "BulletUmbrellaCanopyCompact",
+        "rate": 3
+      },
+      {
+        "target": "BulletUmbrellaCanopyWide",
+        "rate": 3
+      },
+      {
+        "target": "BulletUmbrellaCanopyNormal",
+        "rate": 4.75
+      },
+      {
+        "target": "Chariot",
+        "rate": 3.64
+      },
+      {
+        "target": "Gachihoko_Barrier",
+        "rate": 2.5
+      },
+      {
+        "target": "GreatBarrier_Barrier",
+        "rate": 2.5
+      },
+      {
+        "target": "GreatBarrier_WeakPoint",
+        "rate": 2.5
+      },
+      {
+        "target": "NiceBall_Armor",
+        "rate": 3.75
+      },
+      {
+        "target": "ShockSonar",
+        "rate": 2.5
+      },
+      {
+        "target": "Wsb_Flag",
+        "rate": 5
+      },
+      {
+        "target": "Wsb_Shield",
+        "rate": 2.5
+      },
+      {
+        "target": "Wsb_Sprinkler",
+        "rate": 5
+      }
+    ]
+  },
   "RollerCore": {
     "mainWeaponIds": [1000, 1001, 1020, 1021, 1030, 1010, 1011, 1040, 1041],
     "subWeaponIds": [],

--- a/app/features/object-damage-calculator/core/object-dmg.json
+++ b/app/features/object-damage-calculator/core/object-dmg.json
@@ -1995,6 +1995,10 @@
         "rate": 2
       },
       {
+        "target": "BlowerInhale",
+        "rate": 2
+      },
+      {
         "target": "BulletUmbrellaCanopyCompact",
         "rate": 3
       },

--- a/app/features/object-damage-calculator/core/object-dmg.json
+++ b/app/features/object-damage-calculator/core/object-dmg.json
@@ -1,6 +1,11 @@
 {
   "Blaster_BlasterMiddle": {
-    "mainWeaponIds": [210, 260],
+    "mainWeaponIds": [
+      210,
+      211,
+      260,
+      261
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -47,7 +52,10 @@
     ]
   },
   "Blaster_BlasterShort": {
-    "mainWeaponIds": [200, 201],
+    "mainWeaponIds": [
+      200,
+      201
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -94,7 +102,13 @@
     ]
   },
   "Blaster_KillOneShot": {
-    "mainWeaponIds": [220, 210, 260],
+    "mainWeaponIds": [
+      220,
+      210,
+      211,
+      260,
+      261
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -141,7 +155,15 @@
     ]
   },
   "Blaster": {
-    "mainWeaponIds": [250, 251, 230, 231, 240, 241, 220],
+    "mainWeaponIds": [
+      250,
+      251,
+      230,
+      231,
+      240,
+      241,
+      220
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -190,7 +212,9 @@
   "BlowerExhale_BombCore": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [8],
+    "specialWeaponIds": [
+      8
+    ],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -245,7 +269,9 @@
   "BlowerInhale": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [8],
+    "specialWeaponIds": [
+      8
+    ],
     "rates": [
       {
         "target": "GreatBarrier_Barrier",
@@ -259,7 +285,9 @@
   },
   "Bomb_CurlingBullet": {
     "mainWeaponIds": [],
-    "subWeaponIds": [6],
+    "subWeaponIds": [
+      6
+    ],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -286,7 +314,11 @@
   },
   "Bomb_DirectHit": {
     "mainWeaponIds": [],
-    "subWeaponIds": [2, 7, 0],
+    "subWeaponIds": [
+      2,
+      7,
+      0
+    ],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -337,7 +369,9 @@
   },
   "Bomb_Fizzy": {
     "mainWeaponIds": [],
-    "subWeaponIds": [5],
+    "subWeaponIds": [
+      5
+    ],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -396,7 +430,9 @@
   },
   "Bomb_Suction": {
     "mainWeaponIds": [],
-    "subWeaponIds": [1],
+    "subWeaponIds": [
+      1
+    ],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -447,7 +483,9 @@
   },
   "Bomb_TorpedoBullet": {
     "mainWeaponIds": [],
-    "subWeaponIds": [13],
+    "subWeaponIds": [
+      13
+    ],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -502,7 +540,9 @@
   },
   "Bomb_TorpedoSplashBurst": {
     "mainWeaponIds": [],
-    "subWeaponIds": [13],
+    "subWeaponIds": [
+      13
+    ],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -517,7 +557,9 @@
   },
   "Bomb_Trap": {
     "mainWeaponIds": [],
-    "subWeaponIds": [10],
+    "subWeaponIds": [
+      10
+    ],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -568,7 +610,12 @@
   },
   "Bomb": {
     "mainWeaponIds": [],
-    "subWeaponIds": [6, 2, 7, 0],
+    "subWeaponIds": [
+      6,
+      2,
+      7,
+      0
+    ],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -618,7 +665,14 @@
     ]
   },
   "BrushCore": {
-    "mainWeaponIds": [1120, 1100, 1101, 1110, 1111],
+    "mainWeaponIds": [
+      1120,
+      1121,
+      1100,
+      1101,
+      1110,
+      1111
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -641,7 +695,14 @@
     ]
   },
   "BrushSplash": {
-    "mainWeaponIds": [1120, 1100, 1101, 1110, 1111],
+    "mainWeaponIds": [
+      1120,
+      1121,
+      1100,
+      1101,
+      1110,
+      1111
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -698,7 +759,9 @@
   "Castle": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [17],
+    "specialWeaponIds": [
+      17
+    ],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -751,7 +814,11 @@
     ]
   },
   "ChargerFull_Light": {
-    "mainWeaponIds": [2050, 2070],
+    "mainWeaponIds": [
+      2050,
+      2070,
+      2071
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -806,7 +873,10 @@
     ]
   },
   "ChargerFull_Long": {
-    "mainWeaponIds": [2040, 2030],
+    "mainWeaponIds": [
+      2040,
+      2030
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -861,7 +931,15 @@
     ]
   },
   "ChargerFull": {
-    "mainWeaponIds": [2060, 2061, 2020, 2021, 2010, 2011, 2000],
+    "mainWeaponIds": [
+      2060,
+      2061,
+      2020,
+      2021,
+      2010,
+      2011,
+      2000
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -916,7 +994,11 @@
     ]
   },
   "Charger_Light": {
-    "mainWeaponIds": [2050, 2070],
+    "mainWeaponIds": [
+      2050,
+      2070,
+      2071
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -971,7 +1053,10 @@
     ]
   },
   "Charger_Long": {
-    "mainWeaponIds": [2040, 2030],
+    "mainWeaponIds": [
+      2040,
+      2030
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1026,7 +1111,15 @@
     ]
   },
   "Charger": {
-    "mainWeaponIds": [2060, 2061, 2020, 2021, 2010, 2011, 2000],
+    "mainWeaponIds": [
+      2060,
+      2061,
+      2020,
+      2021,
+      2010,
+      2011,
+      2000
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1083,7 +1176,9 @@
   "Chariot_Body": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [12],
+    "specialWeaponIds": [
+      12
+    ],
     "rates": [
       {
         "target": "GreatBarrier_WeakPoint",
@@ -1110,7 +1205,9 @@
   "Chariot_Cannon": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [12],
+    "specialWeaponIds": [
+      12
+    ],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -1162,14 +1259,82 @@
       }
     ]
   },
+  "Chimney": {
+    "mainWeaponIds": [],
+    "subWeaponIds": [],
+    "specialWeaponIds": [
+      19
+    ],
+    "rates": [
+      {
+        "target": "BulletUmbrellaCanopyCompact",
+        "rate": 1
+      },
+      {
+        "target": "BulletUmbrellaCanopyNormal",
+        "rate": 1
+      },
+      {
+        "target": "NiceBall_Armor",
+        "rate": 1
+      }
+    ]
+  },
   "Default": {
     "mainWeaponIds": [
-      220, 210, 260, 1120, 1100, 1101, 1110, 1111, 2060, 2061, 2050, 2040, 2030,
-      2020, 2021, 2010, 2011, 2070, 2000, 1000, 1001, 1020, 1021, 1030, 1010,
-      1011, 1040, 1041, 6020, 6000, 6001, 6010, 6011
+      220,
+      210,
+      211,
+      260,
+      261,
+      1120,
+      1121,
+      1100,
+      1101,
+      1110,
+      1111,
+      2060,
+      2061,
+      2050,
+      2040,
+      2030,
+      2020,
+      2021,
+      2010,
+      2011,
+      2070,
+      2071,
+      2000,
+      1000,
+      1001,
+      1020,
+      1021,
+      1030,
+      1010,
+      1011,
+      1040,
+      1041,
+      6020,
+      6000,
+      6001,
+      6010,
+      6011
     ],
-    "subWeaponIds": [8, 6, 12, 9, 11],
-    "specialWeaponIds": [12, 15, 16, 2, 7],
+    "subWeaponIds": [
+      8,
+      6,
+      12,
+      9,
+      11
+    ],
+    "specialWeaponIds": [
+      12,
+      19,
+      15,
+      16,
+      2,
+      7
+    ],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -1197,10 +1362,25 @@
       }
     ]
   },
+  "InkStormRain": {
+    "mainWeaponIds": [],
+    "subWeaponIds": [],
+    "specialWeaponIds": [
+      5
+    ],
+    "rates": [
+      {
+        "target": "BlowerInhale",
+        "rate": 1
+      }
+    ]
+  },
   "InkStorm": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [5],
+    "specialWeaponIds": [
+      5
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1251,7 +1431,9 @@
   "Jetpack_BombCore": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [10],
+    "specialWeaponIds": [
+      10
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1310,7 +1492,9 @@
   "Jetpack_Bullet": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [10],
+    "specialWeaponIds": [
+      10
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1369,7 +1553,9 @@
   "Jetpack_Jet": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [10],
+    "specialWeaponIds": [
+      10
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1422,7 +1608,10 @@
     ]
   },
   "Maneuver_Short": {
-    "mainWeaponIds": [5000, 5001],
+    "mainWeaponIds": [
+      5000,
+      5001
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1457,7 +1646,15 @@
     ]
   },
   "Maneuver": {
-    "mainWeaponIds": [5030, 5031, 5020, 5010, 5040, 5041],
+    "mainWeaponIds": [
+      5030,
+      5031,
+      5020,
+      5010,
+      5011,
+      5040,
+      5041
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1494,7 +1691,9 @@
   "MicroLaser": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [9],
+    "specialWeaponIds": [
+      9
+    ],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -1537,7 +1736,9 @@
   "MultiMissile_BombCore": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [4],
+    "specialWeaponIds": [
+      4
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1592,7 +1793,9 @@
   "MultiMissile_Bullet": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [4],
+    "specialWeaponIds": [
+      4
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1647,7 +1850,9 @@
   "NiceBall": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [6],
+    "specialWeaponIds": [
+      6
+    ],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -1741,7 +1946,9 @@
   "Pogo": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [18],
+    "specialWeaponIds": [
+      18
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1752,12 +1959,12 @@
         "rate": 3
       },
       {
-        "target": "BulletUmbrellaCanopyWide",
-        "rate": 3
-      },
-      {
         "target": "BulletUmbrellaCanopyNormal",
         "rate": 4.75
+      },
+      {
+        "target": "BulletUmbrellaCanopyWide",
+        "rate": 3
       },
       {
         "target": "Chariot",
@@ -1798,7 +2005,17 @@
     ]
   },
   "RollerCore": {
-    "mainWeaponIds": [1000, 1001, 1020, 1021, 1030, 1010, 1011, 1040, 1041],
+    "mainWeaponIds": [
+      1000,
+      1001,
+      1020,
+      1021,
+      1030,
+      1010,
+      1011,
+      1040,
+      1041
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1821,7 +2038,10 @@
     ]
   },
   "RollerSplash_Compact": {
-    "mainWeaponIds": [1000, 1001],
+    "mainWeaponIds": [
+      1000,
+      1001
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1876,7 +2096,10 @@
     ]
   },
   "RollerSplash_Heavy": {
-    "mainWeaponIds": [1020, 1021],
+    "mainWeaponIds": [
+      1020,
+      1021
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1931,7 +2154,9 @@
     ]
   },
   "RollerSplash_Hunter": {
-    "mainWeaponIds": [1030],
+    "mainWeaponIds": [
+      1030
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1986,16 +2211,19 @@
     ]
   },
   "RollerSplash_Wide": {
-    "mainWeaponIds": [1040, 1041],
+    "mainWeaponIds": [
+      1040,
+      1041
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
       {
-        "target": "Bomb_TorpedoBullet",
+        "target": "BlowerInhale",
         "rate": 2
       },
       {
-        "target": "BlowerInhale",
+        "target": "Bomb_TorpedoBullet",
         "rate": 2
       },
       {
@@ -2049,7 +2277,10 @@
     ]
   },
   "RollerSplash": {
-    "mainWeaponIds": [1010, 1011],
+    "mainWeaponIds": [
+      1010,
+      1011
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2104,7 +2335,12 @@
     ]
   },
   "Saber_ChargeShot": {
-    "mainWeaponIds": [8010, 8011, 8000],
+    "mainWeaponIds": [
+      8010,
+      8011,
+      8000,
+      8001
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2163,7 +2399,12 @@
     ]
   },
   "Saber_ChargeSlash": {
-    "mainWeaponIds": [8010, 8011, 8000],
+    "mainWeaponIds": [
+      8010,
+      8011,
+      8000,
+      8001
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2222,7 +2463,12 @@
     ]
   },
   "Saber_Shot": {
-    "mainWeaponIds": [8010, 8011, 8000],
+    "mainWeaponIds": [
+      8010,
+      8011,
+      8000,
+      8001
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2281,7 +2527,12 @@
     ]
   },
   "Saber_Slash": {
-    "mainWeaponIds": [8010, 8011, 8000],
+    "mainWeaponIds": [
+      8010,
+      8011,
+      8000,
+      8001
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2340,7 +2591,10 @@
     ]
   },
   "ShelterCanopy_Compact": {
-    "mainWeaponIds": [6020],
+    "mainWeaponIds": [
+      6020,
+      6021
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2391,7 +2645,10 @@
     ]
   },
   "ShelterCanopy_Wide": {
-    "mainWeaponIds": [6010, 6011],
+    "mainWeaponIds": [
+      6010,
+      6011
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2442,7 +2699,10 @@
     ]
   },
   "ShelterCanopy": {
-    "mainWeaponIds": [6000, 6001],
+    "mainWeaponIds": [
+      6000,
+      6001
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2493,7 +2753,10 @@
     ]
   },
   "ShelterShot_Compact": {
-    "mainWeaponIds": [6020],
+    "mainWeaponIds": [
+      6020,
+      6021
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2552,7 +2815,10 @@
     ]
   },
   "ShelterShot_Wide": {
-    "mainWeaponIds": [6010, 6011],
+    "mainWeaponIds": [
+      6010,
+      6011
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2611,7 +2877,10 @@
     ]
   },
   "ShelterShot": {
-    "mainWeaponIds": [6000, 6001],
+    "mainWeaponIds": [
+      6000,
+      6001
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2671,7 +2940,9 @@
   },
   "Shield": {
     "mainWeaponIds": [],
-    "subWeaponIds": [4],
+    "subWeaponIds": [
+      4
+    ],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -2695,7 +2966,9 @@
   "ShockSonar_Wave": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [7],
+    "specialWeaponIds": [
+      7
+    ],
     "rates": [
       {
         "target": "Chariot",
@@ -2732,7 +3005,10 @@
     ]
   },
   "Shooter_Blaze": {
-    "mainWeaponIds": [30, 31],
+    "mainWeaponIds": [
+      30,
+      31
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2767,7 +3043,10 @@
     ]
   },
   "Shooter_Expert": {
-    "mainWeaponIds": [70, 71],
+    "mainWeaponIds": [
+      70,
+      71
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2802,7 +3081,10 @@
     ]
   },
   "Shooter_First": {
-    "mainWeaponIds": [10, 11],
+    "mainWeaponIds": [
+      10,
+      11
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2837,7 +3119,10 @@
     ]
   },
   "Shooter_FlashRepeat": {
-    "mainWeaponIds": [400],
+    "mainWeaponIds": [
+      400,
+      401
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2884,7 +3169,10 @@
     ]
   },
   "Shooter_Flash": {
-    "mainWeaponIds": [400],
+    "mainWeaponIds": [
+      400,
+      401
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2931,7 +3219,9 @@
     ]
   },
   "Shooter_Gravity": {
-    "mainWeaponIds": [50],
+    "mainWeaponIds": [
+      50
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2974,7 +3264,10 @@
     ]
   },
   "Shooter_Heavy": {
-    "mainWeaponIds": [80, 81],
+    "mainWeaponIds": [
+      80,
+      81
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3017,7 +3310,10 @@
     ]
   },
   "Shooter_Long": {
-    "mainWeaponIds": [90, 91],
+    "mainWeaponIds": [
+      90,
+      91
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3052,7 +3348,10 @@
     ]
   },
   "Shooter_Precision": {
-    "mainWeaponIds": [20, 21],
+    "mainWeaponIds": [
+      20,
+      21
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3087,7 +3386,10 @@
     ]
   },
   "Shooter_Short": {
-    "mainWeaponIds": [0, 1],
+    "mainWeaponIds": [
+      0,
+      1
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3126,7 +3428,10 @@
     ]
   },
   "Shooter_TripleMiddle": {
-    "mainWeaponIds": [310, 311],
+    "mainWeaponIds": [
+      310,
+      311
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3173,7 +3478,10 @@
     ]
   },
   "Shooter_TripleQuick": {
-    "mainWeaponIds": [300, 301],
+    "mainWeaponIds": [
+      300,
+      301
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3220,7 +3528,17 @@
     ]
   },
   "Shooter": {
-    "mainWeaponIds": [400, 40, 41, 45, 100, 101, 60, 61],
+    "mainWeaponIds": [
+      400,
+      401,
+      40,
+      41,
+      45,
+      100,
+      101,
+      60,
+      61
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3257,7 +3575,9 @@
   "Skewer_Body": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [13],
+    "specialWeaponIds": [
+      13
+    ],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -3308,7 +3628,9 @@
   "Skewer": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [13],
+    "specialWeaponIds": [
+      13
+    ],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -3361,7 +3683,10 @@
     ]
   },
   "Slosher_Bathtub": {
-    "mainWeaponIds": [3030, 3031],
+    "mainWeaponIds": [
+      3030,
+      3031
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3404,7 +3729,9 @@
     ]
   },
   "Slosher_WashtubBombCore": {
-    "mainWeaponIds": [3040],
+    "mainWeaponIds": [
+      3040
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3447,7 +3774,9 @@
     ]
   },
   "Slosher_Washtub": {
-    "mainWeaponIds": [3040],
+    "mainWeaponIds": [
+      3040
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3494,7 +3823,15 @@
     ]
   },
   "Slosher": {
-    "mainWeaponIds": [3010, 3011, 3050, 3020, 3021, 3000, 3001],
+    "mainWeaponIds": [
+      3010,
+      3011,
+      3050,
+      3020,
+      3021,
+      3000,
+      3001
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3541,7 +3878,17 @@
     ]
   },
   "Spinner": {
-    "mainWeaponIds": [4030, 4031, 4050, 4020, 4000, 4001, 4040, 4010, 4011],
+    "mainWeaponIds": [
+      4030,
+      4031,
+      4050,
+      4020,
+      4000,
+      4001,
+      4040,
+      4010,
+      4011
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3577,7 +3924,9 @@
   },
   "Sprinkler": {
     "mainWeaponIds": [],
-    "subWeaponIds": [3],
+    "subWeaponIds": [
+      3
+    ],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -3599,7 +3948,10 @@
     ]
   },
   "Stringer_Short": {
-    "mainWeaponIds": [7020],
+    "mainWeaponIds": [
+      7020,
+      7021
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3646,7 +3998,10 @@
     ]
   },
   "Stringer": {
-    "mainWeaponIds": [7010, 7011],
+    "mainWeaponIds": [
+      7010,
+      7011
+    ],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3703,7 +4058,9 @@
   "SuperHook": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [3],
+    "specialWeaponIds": [
+      3
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -3754,7 +4111,9 @@
   "TripleTornado": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [14],
+    "specialWeaponIds": [
+      14
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -3813,7 +4172,9 @@
   "UltraShot": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [1],
+    "specialWeaponIds": [
+      1
+    ],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -3860,7 +4221,9 @@
   "UltraStamp_Swing": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [11],
+    "specialWeaponIds": [
+      11
+    ],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -3915,7 +4278,9 @@
   "UltraStamp_Throw_BombCore": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [11],
+    "specialWeaponIds": [
+      11
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -3974,7 +4339,9 @@
   "UltraStamp_Throw": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [11],
+    "specialWeaponIds": [
+      11
+    ],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",

--- a/app/features/object-damage-calculator/core/object-dmg.json
+++ b/app/features/object-damage-calculator/core/object-dmg.json
@@ -1,11 +1,6 @@
 {
   "Blaster_BlasterMiddle": {
-    "mainWeaponIds": [
-      210,
-      211,
-      260,
-      261
-    ],
+    "mainWeaponIds": [210, 211, 260, 261],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -52,10 +47,7 @@
     ]
   },
   "Blaster_BlasterShort": {
-    "mainWeaponIds": [
-      200,
-      201
-    ],
+    "mainWeaponIds": [200, 201],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -102,13 +94,7 @@
     ]
   },
   "Blaster_KillOneShot": {
-    "mainWeaponIds": [
-      220,
-      210,
-      211,
-      260,
-      261
-    ],
+    "mainWeaponIds": [220, 210, 211, 260, 261],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -155,15 +141,7 @@
     ]
   },
   "Blaster": {
-    "mainWeaponIds": [
-      250,
-      251,
-      230,
-      231,
-      240,
-      241,
-      220
-    ],
+    "mainWeaponIds": [250, 251, 230, 231, 240, 241, 220],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -212,9 +190,7 @@
   "BlowerExhale_BombCore": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      8
-    ],
+    "specialWeaponIds": [8],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -269,9 +245,7 @@
   "BlowerInhale": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      8
-    ],
+    "specialWeaponIds": [8],
     "rates": [
       {
         "target": "GreatBarrier_Barrier",
@@ -285,9 +259,7 @@
   },
   "Bomb_CurlingBullet": {
     "mainWeaponIds": [],
-    "subWeaponIds": [
-      6
-    ],
+    "subWeaponIds": [6],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -314,11 +286,7 @@
   },
   "Bomb_DirectHit": {
     "mainWeaponIds": [],
-    "subWeaponIds": [
-      2,
-      7,
-      0
-    ],
+    "subWeaponIds": [2, 7, 0],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -369,9 +337,7 @@
   },
   "Bomb_Fizzy": {
     "mainWeaponIds": [],
-    "subWeaponIds": [
-      5
-    ],
+    "subWeaponIds": [5],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -430,9 +396,7 @@
   },
   "Bomb_Suction": {
     "mainWeaponIds": [],
-    "subWeaponIds": [
-      1
-    ],
+    "subWeaponIds": [1],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -483,9 +447,7 @@
   },
   "Bomb_TorpedoBullet": {
     "mainWeaponIds": [],
-    "subWeaponIds": [
-      13
-    ],
+    "subWeaponIds": [13],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -540,9 +502,7 @@
   },
   "Bomb_TorpedoSplashBurst": {
     "mainWeaponIds": [],
-    "subWeaponIds": [
-      13
-    ],
+    "subWeaponIds": [13],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -557,9 +517,7 @@
   },
   "Bomb_Trap": {
     "mainWeaponIds": [],
-    "subWeaponIds": [
-      10
-    ],
+    "subWeaponIds": [10],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -610,12 +568,7 @@
   },
   "Bomb": {
     "mainWeaponIds": [],
-    "subWeaponIds": [
-      6,
-      2,
-      7,
-      0
-    ],
+    "subWeaponIds": [6, 2, 7, 0],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -665,14 +618,7 @@
     ]
   },
   "BrushCore": {
-    "mainWeaponIds": [
-      1120,
-      1121,
-      1100,
-      1101,
-      1110,
-      1111
-    ],
+    "mainWeaponIds": [1120, 1121, 1100, 1101, 1110, 1111],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -695,14 +641,7 @@
     ]
   },
   "BrushSplash": {
-    "mainWeaponIds": [
-      1120,
-      1121,
-      1100,
-      1101,
-      1110,
-      1111
-    ],
+    "mainWeaponIds": [1120, 1121, 1100, 1101, 1110, 1111],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -759,9 +698,7 @@
   "Castle": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      17
-    ],
+    "specialWeaponIds": [17],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -814,11 +751,7 @@
     ]
   },
   "ChargerFull_Light": {
-    "mainWeaponIds": [
-      2050,
-      2070,
-      2071
-    ],
+    "mainWeaponIds": [2050, 2070, 2071],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -873,10 +806,7 @@
     ]
   },
   "ChargerFull_Long": {
-    "mainWeaponIds": [
-      2040,
-      2030
-    ],
+    "mainWeaponIds": [2040, 2030],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -931,15 +861,7 @@
     ]
   },
   "ChargerFull": {
-    "mainWeaponIds": [
-      2060,
-      2061,
-      2020,
-      2021,
-      2010,
-      2011,
-      2000
-    ],
+    "mainWeaponIds": [2060, 2061, 2020, 2021, 2010, 2011, 2000],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -994,11 +916,7 @@
     ]
   },
   "Charger_Light": {
-    "mainWeaponIds": [
-      2050,
-      2070,
-      2071
-    ],
+    "mainWeaponIds": [2050, 2070, 2071],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1053,10 +971,7 @@
     ]
   },
   "Charger_Long": {
-    "mainWeaponIds": [
-      2040,
-      2030
-    ],
+    "mainWeaponIds": [2040, 2030],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1111,15 +1026,7 @@
     ]
   },
   "Charger": {
-    "mainWeaponIds": [
-      2060,
-      2061,
-      2020,
-      2021,
-      2010,
-      2011,
-      2000
-    ],
+    "mainWeaponIds": [2060, 2061, 2020, 2021, 2010, 2011, 2000],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1176,9 +1083,7 @@
   "Chariot_Body": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      12
-    ],
+    "specialWeaponIds": [12],
     "rates": [
       {
         "target": "GreatBarrier_WeakPoint",
@@ -1205,9 +1110,7 @@
   "Chariot_Cannon": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      12
-    ],
+    "specialWeaponIds": [12],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -1262,9 +1165,7 @@
   "Chimney": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      19
-    ],
+    "specialWeaponIds": [19],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -1282,59 +1183,12 @@
   },
   "Default": {
     "mainWeaponIds": [
-      220,
-      210,
-      211,
-      260,
-      261,
-      1120,
-      1121,
-      1100,
-      1101,
-      1110,
-      1111,
-      2060,
-      2061,
-      2050,
-      2040,
-      2030,
-      2020,
-      2021,
-      2010,
-      2011,
-      2070,
-      2071,
-      2000,
-      1000,
-      1001,
-      1020,
-      1021,
-      1030,
-      1010,
-      1011,
-      1040,
-      1041,
-      6020,
-      6000,
-      6001,
-      6010,
-      6011
+      220, 210, 211, 260, 261, 1120, 1121, 1100, 1101, 1110, 1111, 2060, 2061,
+      2050, 2040, 2030, 2020, 2021, 2010, 2011, 2070, 2071, 2000, 1000, 1001,
+      1020, 1021, 1030, 1010, 1011, 1040, 1041, 6020, 6000, 6001, 6010, 6011
     ],
-    "subWeaponIds": [
-      8,
-      6,
-      12,
-      9,
-      11
-    ],
-    "specialWeaponIds": [
-      12,
-      19,
-      15,
-      16,
-      2,
-      7
-    ],
+    "subWeaponIds": [8, 6, 12, 9, 11],
+    "specialWeaponIds": [12, 19, 15, 16, 2, 7],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -1365,9 +1219,7 @@
   "InkStormRain": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      5
-    ],
+    "specialWeaponIds": [5],
     "rates": [
       {
         "target": "BlowerInhale",
@@ -1378,9 +1230,7 @@
   "InkStorm": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      5
-    ],
+    "specialWeaponIds": [5],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1431,9 +1281,7 @@
   "Jetpack_BombCore": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      10
-    ],
+    "specialWeaponIds": [10],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1492,9 +1340,7 @@
   "Jetpack_Bullet": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      10
-    ],
+    "specialWeaponIds": [10],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1553,9 +1399,7 @@
   "Jetpack_Jet": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      10
-    ],
+    "specialWeaponIds": [10],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1608,10 +1452,7 @@
     ]
   },
   "Maneuver_Short": {
-    "mainWeaponIds": [
-      5000,
-      5001
-    ],
+    "mainWeaponIds": [5000, 5001],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1646,15 +1487,7 @@
     ]
   },
   "Maneuver": {
-    "mainWeaponIds": [
-      5030,
-      5031,
-      5020,
-      5010,
-      5011,
-      5040,
-      5041
-    ],
+    "mainWeaponIds": [5030, 5031, 5020, 5010, 5011, 5040, 5041],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -1691,9 +1524,7 @@
   "MicroLaser": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      9
-    ],
+    "specialWeaponIds": [9],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -1736,9 +1567,7 @@
   "MultiMissile_BombCore": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      4
-    ],
+    "specialWeaponIds": [4],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1793,9 +1622,7 @@
   "MultiMissile_Bullet": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      4
-    ],
+    "specialWeaponIds": [4],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -1850,9 +1677,7 @@
   "NiceBall": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      6
-    ],
+    "specialWeaponIds": [6],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -1946,9 +1771,7 @@
   "Pogo": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      18
-    ],
+    "specialWeaponIds": [18],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -2005,17 +1828,7 @@
     ]
   },
   "RollerCore": {
-    "mainWeaponIds": [
-      1000,
-      1001,
-      1020,
-      1021,
-      1030,
-      1010,
-      1011,
-      1040,
-      1041
-    ],
+    "mainWeaponIds": [1000, 1001, 1020, 1021, 1030, 1010, 1011, 1040, 1041],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2038,10 +1851,7 @@
     ]
   },
   "RollerSplash_Compact": {
-    "mainWeaponIds": [
-      1000,
-      1001
-    ],
+    "mainWeaponIds": [1000, 1001],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2096,10 +1906,7 @@
     ]
   },
   "RollerSplash_Heavy": {
-    "mainWeaponIds": [
-      1020,
-      1021
-    ],
+    "mainWeaponIds": [1020, 1021],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2154,9 +1961,7 @@
     ]
   },
   "RollerSplash_Hunter": {
-    "mainWeaponIds": [
-      1030
-    ],
+    "mainWeaponIds": [1030],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2211,10 +2016,7 @@
     ]
   },
   "RollerSplash_Wide": {
-    "mainWeaponIds": [
-      1040,
-      1041
-    ],
+    "mainWeaponIds": [1040, 1041],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2277,10 +2079,7 @@
     ]
   },
   "RollerSplash": {
-    "mainWeaponIds": [
-      1010,
-      1011
-    ],
+    "mainWeaponIds": [1010, 1011],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2335,12 +2134,7 @@
     ]
   },
   "Saber_ChargeShot": {
-    "mainWeaponIds": [
-      8010,
-      8011,
-      8000,
-      8001
-    ],
+    "mainWeaponIds": [8010, 8011, 8000, 8001],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2399,12 +2193,7 @@
     ]
   },
   "Saber_ChargeSlash": {
-    "mainWeaponIds": [
-      8010,
-      8011,
-      8000,
-      8001
-    ],
+    "mainWeaponIds": [8010, 8011, 8000, 8001],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2463,12 +2252,7 @@
     ]
   },
   "Saber_Shot": {
-    "mainWeaponIds": [
-      8010,
-      8011,
-      8000,
-      8001
-    ],
+    "mainWeaponIds": [8010, 8011, 8000, 8001],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2527,12 +2311,7 @@
     ]
   },
   "Saber_Slash": {
-    "mainWeaponIds": [
-      8010,
-      8011,
-      8000,
-      8001
-    ],
+    "mainWeaponIds": [8010, 8011, 8000, 8001],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2591,10 +2370,7 @@
     ]
   },
   "ShelterCanopy_Compact": {
-    "mainWeaponIds": [
-      6020,
-      6021
-    ],
+    "mainWeaponIds": [6020, 6021],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2645,10 +2421,7 @@
     ]
   },
   "ShelterCanopy_Wide": {
-    "mainWeaponIds": [
-      6010,
-      6011
-    ],
+    "mainWeaponIds": [6010, 6011],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2699,10 +2472,7 @@
     ]
   },
   "ShelterCanopy": {
-    "mainWeaponIds": [
-      6000,
-      6001
-    ],
+    "mainWeaponIds": [6000, 6001],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2753,10 +2523,7 @@
     ]
   },
   "ShelterShot_Compact": {
-    "mainWeaponIds": [
-      6020,
-      6021
-    ],
+    "mainWeaponIds": [6020, 6021],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2815,10 +2582,7 @@
     ]
   },
   "ShelterShot_Wide": {
-    "mainWeaponIds": [
-      6010,
-      6011
-    ],
+    "mainWeaponIds": [6010, 6011],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2877,10 +2641,7 @@
     ]
   },
   "ShelterShot": {
-    "mainWeaponIds": [
-      6000,
-      6001
-    ],
+    "mainWeaponIds": [6000, 6001],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -2940,9 +2701,7 @@
   },
   "Shield": {
     "mainWeaponIds": [],
-    "subWeaponIds": [
-      4
-    ],
+    "subWeaponIds": [4],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -2966,9 +2725,7 @@
   "ShockSonar_Wave": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      7
-    ],
+    "specialWeaponIds": [7],
     "rates": [
       {
         "target": "Chariot",
@@ -3005,10 +2762,7 @@
     ]
   },
   "Shooter_Blaze": {
-    "mainWeaponIds": [
-      30,
-      31
-    ],
+    "mainWeaponIds": [30, 31],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3043,10 +2797,7 @@
     ]
   },
   "Shooter_Expert": {
-    "mainWeaponIds": [
-      70,
-      71
-    ],
+    "mainWeaponIds": [70, 71],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3081,10 +2832,7 @@
     ]
   },
   "Shooter_First": {
-    "mainWeaponIds": [
-      10,
-      11
-    ],
+    "mainWeaponIds": [10, 11],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3119,10 +2867,7 @@
     ]
   },
   "Shooter_FlashRepeat": {
-    "mainWeaponIds": [
-      400,
-      401
-    ],
+    "mainWeaponIds": [400, 401],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3169,10 +2914,7 @@
     ]
   },
   "Shooter_Flash": {
-    "mainWeaponIds": [
-      400,
-      401
-    ],
+    "mainWeaponIds": [400, 401],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3219,9 +2961,7 @@
     ]
   },
   "Shooter_Gravity": {
-    "mainWeaponIds": [
-      50
-    ],
+    "mainWeaponIds": [50],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3264,10 +3004,7 @@
     ]
   },
   "Shooter_Heavy": {
-    "mainWeaponIds": [
-      80,
-      81
-    ],
+    "mainWeaponIds": [80, 81],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3310,10 +3047,7 @@
     ]
   },
   "Shooter_Long": {
-    "mainWeaponIds": [
-      90,
-      91
-    ],
+    "mainWeaponIds": [90, 91],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3348,10 +3082,7 @@
     ]
   },
   "Shooter_Precision": {
-    "mainWeaponIds": [
-      20,
-      21
-    ],
+    "mainWeaponIds": [20, 21],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3386,10 +3117,7 @@
     ]
   },
   "Shooter_Short": {
-    "mainWeaponIds": [
-      0,
-      1
-    ],
+    "mainWeaponIds": [0, 1],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3428,10 +3156,7 @@
     ]
   },
   "Shooter_TripleMiddle": {
-    "mainWeaponIds": [
-      310,
-      311
-    ],
+    "mainWeaponIds": [310, 311],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3478,10 +3203,7 @@
     ]
   },
   "Shooter_TripleQuick": {
-    "mainWeaponIds": [
-      300,
-      301
-    ],
+    "mainWeaponIds": [300, 301],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3528,17 +3250,7 @@
     ]
   },
   "Shooter": {
-    "mainWeaponIds": [
-      400,
-      401,
-      40,
-      41,
-      45,
-      100,
-      101,
-      60,
-      61
-    ],
+    "mainWeaponIds": [400, 401, 40, 41, 45, 100, 101, 60, 61],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3575,9 +3287,7 @@
   "Skewer_Body": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      13
-    ],
+    "specialWeaponIds": [13],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -3628,9 +3338,7 @@
   "Skewer": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      13
-    ],
+    "specialWeaponIds": [13],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -3683,10 +3391,7 @@
     ]
   },
   "Slosher_Bathtub": {
-    "mainWeaponIds": [
-      3030,
-      3031
-    ],
+    "mainWeaponIds": [3030, 3031],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3729,9 +3434,7 @@
     ]
   },
   "Slosher_WashtubBombCore": {
-    "mainWeaponIds": [
-      3040
-    ],
+    "mainWeaponIds": [3040],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3774,9 +3477,7 @@
     ]
   },
   "Slosher_Washtub": {
-    "mainWeaponIds": [
-      3040
-    ],
+    "mainWeaponIds": [3040],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3823,15 +3524,7 @@
     ]
   },
   "Slosher": {
-    "mainWeaponIds": [
-      3010,
-      3011,
-      3050,
-      3020,
-      3021,
-      3000,
-      3001
-    ],
+    "mainWeaponIds": [3010, 3011, 3050, 3020, 3021, 3000, 3001],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3878,17 +3571,7 @@
     ]
   },
   "Spinner": {
-    "mainWeaponIds": [
-      4030,
-      4031,
-      4050,
-      4020,
-      4000,
-      4001,
-      4040,
-      4010,
-      4011
-    ],
+    "mainWeaponIds": [4030, 4031, 4050, 4020, 4000, 4001, 4040, 4010, 4011],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3924,9 +3607,7 @@
   },
   "Sprinkler": {
     "mainWeaponIds": [],
-    "subWeaponIds": [
-      3
-    ],
+    "subWeaponIds": [3],
     "specialWeaponIds": [],
     "rates": [
       {
@@ -3948,10 +3629,7 @@
     ]
   },
   "Stringer_Short": {
-    "mainWeaponIds": [
-      7020,
-      7021
-    ],
+    "mainWeaponIds": [7020, 7021],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -3998,10 +3676,7 @@
     ]
   },
   "Stringer": {
-    "mainWeaponIds": [
-      7010,
-      7011
-    ],
+    "mainWeaponIds": [7010, 7011],
     "subWeaponIds": [],
     "specialWeaponIds": [],
     "rates": [
@@ -4058,9 +3733,7 @@
   "SuperHook": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      3
-    ],
+    "specialWeaponIds": [3],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -4111,9 +3784,7 @@
   "TripleTornado": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      14
-    ],
+    "specialWeaponIds": [14],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -4172,9 +3843,7 @@
   "UltraShot": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      1
-    ],
+    "specialWeaponIds": [1],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -4221,9 +3890,7 @@
   "UltraStamp_Swing": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      11
-    ],
+    "specialWeaponIds": [11],
     "rates": [
       {
         "target": "BulletUmbrellaCanopyCompact",
@@ -4278,9 +3945,7 @@
   "UltraStamp_Throw_BombCore": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      11
-    ],
+    "specialWeaponIds": [11],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",
@@ -4339,9 +4004,7 @@
   "UltraStamp_Throw": {
     "mainWeaponIds": [],
     "subWeaponIds": [],
-    "specialWeaponIds": [
-      11
-    ],
+    "specialWeaponIds": [11],
     "rates": [
       {
         "target": "Bomb_TorpedoBullet",

--- a/app/features/object-damage-calculator/core/objectHitPoints.ts
+++ b/app/features/object-damage-calculator/core/objectHitPoints.ts
@@ -17,10 +17,11 @@ import {
 import type { HitPoints } from "../calculator-types";
 
 const WAVE_BREAKER_HP = 400;
-const SPRINKER_HP = 100;
+const SPRINKLER_HP = 120;
 const RAINMAKER_HP = 1000;
 const SPLAT_BRELLA_SHIELD_HP = 500;
 const BOOYAH_BOMB_ARMOR_HP = 470;
+const INK_VAC_HP = 800;
 const BEAKON_HP = 120;
 const TORPEDO_HP = 20;
 
@@ -61,8 +62,9 @@ export const objectHitPoints = (abilityPoints: AbilityPoints): HitPoints => {
     GreatBarrier_Barrier,
     GreatBarrier_WeakPoint,
     NiceBall_Armor: BOOYAH_BOMB_ARMOR_HP, // ??
+    BlowerInhale: INK_VAC_HP,
     ShockSonar: WAVE_BREAKER_HP,
     Wsb_Flag: BEAKON_HP,
-    Wsb_Sprinkler: SPRINKER_HP,
+    Wsb_Sprinkler: SPRINKLER_HP,
   };
 };

--- a/app/features/object-damage-calculator/routes/object-damage-calculator.tsx
+++ b/app/features/object-damage-calculator/routes/object-damage-calculator.tsx
@@ -19,6 +19,7 @@ import {
   SPLASH_WALL_ID,
   SPRINKLER_ID,
   SQUID_BEAKON_ID,
+  INK_VAC_ID,
   TORPEDO_ID,
   WAVE_BREAKER_ID,
 } from "~/modules/in-game-lists";
@@ -196,6 +197,7 @@ function DamageTypesSelect({
 
 const damageReceiverImages: Record<DamageReceiver, string> = {
   Bomb_TorpedoBullet: subWeaponImageUrl(TORPEDO_ID),
+  BlowerInhale: specialWeaponImageUrl(INK_VAC_ID),
   Chariot: specialWeaponImageUrl(CRAB_TANK_ID),
   Gachihoko_Barrier: modeImageUrl("RM"),
   GreatBarrier_Barrier: specialWeaponImageUrl(BIG_BUBBLER_ID),

--- a/scripts/create-analyzer-json.ts
+++ b/scripts/create-analyzer-json.ts
@@ -588,7 +588,8 @@ function parametersToSpecialWeaponResult(params: any) {
       params["HookBlastParam"]?.["DistanceDamage"] ??
       params["spl__BulletBlastParam"]?.["DistanceDamage"] ??
       params["BulletBlastParam"]?.["DistanceDamage"] ??
-      params["IceParam"]?.["BlastParam"]?.["DistanceDamage"],
+      params["IceParam"]?.["BlastParam"]?.["DistanceDamage"] ??
+      params["BlastParamNormal"]?.["DistanceDamage"],
     DirectDamage:
       params["DamageParam"]?.["DirectHitDamage"] ??
       params["spl__BulletSpShockSonarParam"]?.["GeneratorParam"]?.[


### PR DESCRIPTION
- Adds Triple Splashdown's object damage to the DMG Calc
![image](https://github.com/Sendouc/sendou.ink/assets/111416629/5156f9f3-5fac-4add-926c-b62865b438da)
- Makes Sprinkler's HP 120 + adds Ink Vac as a damage reciever (Closes #1555 and #1554)
![image](https://github.com/Sendouc/sendou.ink/assets/111416629/895523c2-c8d7-4202-90e9-559a1e03873b)
![image](https://github.com/Sendouc/sendou.ink/assets/111416629/ca6a3da9-7977-467d-af22-b94333a2cbc0)
