### PR TITLE
Fix broken link to Locales folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Empty DB with the latest migration run. When creating new migrations they should
 
 [Translation Progress](https://github.com/Sendouc/sendou.ink/issues/1104)
 
-sendou.ink can be translated into any language. All the translations can be found in the [locales folder](./public/locales). Here is how you can contribute:
+sendou.ink can be translated into any language. All the translations can be found in the [locales folder](./locales). Here is how you can contribute:
 
 1. Copy a `.json` file from `/en` folder.
 2. Translate lines one by one. For example `"country": "Country",` could become `"country": "Maa",`. Keep the "key" on the left side of : unchanged.


### PR DESCRIPTION
Noticed the link was broken while looking at the translations section of the README, so here is the fix for that.

**Before:**
![image](https://github.com/Sendouc/sendou.ink/assets/104683822/ab71b4cf-4966-4a7c-899f-50624d3027c2)

**After:**
![image](https://github.com/Sendouc/sendou.ink/assets/104683822/8acb72b3-b1ae-4c50-b312-4f35a489dbb0)

