### PR TITLE
Added support for sharing a filter set using the URL

### DIFF
--- a/app/db/tables.ts
+++ b/app/db/tables.ts
@@ -255,13 +255,15 @@ export interface LogInLink {
   userId: number;
 }
 
+export type LFGType =
+  | "PLAYER_FOR_TEAM"
+  | "TEAM_FOR_PLAYER"
+  | "TEAM_FOR_COACH"
+  | "COACH_FOR_TEAM";
+
 export interface LFGPost {
   id: GeneratedAlways<number>;
-  type:
-    | "PLAYER_FOR_TEAM"
-    | "TEAM_FOR_PLAYER"
-    | "TEAM_FOR_COACH"
-    | "COACH_FOR_TEAM";
+  type: LFGType;
   text: string;
   /** e.g. Europe/Helsinki */
   timezone: string;
@@ -454,7 +456,7 @@ export interface TournamentBadgeOwner {
       - If enabled, the Consolation Final.
     - A double elimination stage can have two or three groups:
       - Upper and lower brackets.
-      - If enabled, the Grand Final. 
+      - If enabled, the Grand Final.
 */
 export interface TournamentGroup {
   id: GeneratedAlways<number>;
@@ -523,7 +525,7 @@ export interface TournamentRoundMaps {
   pickBan?: "COUNTERPICK" | "BAN_2" | null;
 }
 
-/** 
+/**
  * A round is a logical structure used to group multiple matches together.
 
   - In round-robin stages, a round can be viewed as a list of matches that can be played at the same time.

--- a/app/db/tables.ts
+++ b/app/db/tables.ts
@@ -261,6 +261,13 @@ export type LFGType =
   | "TEAM_FOR_COACH"
   | "COACH_FOR_TEAM";
 
+export const LFG_TYPES: LFGType[] = [
+  "PLAYER_FOR_TEAM",
+  "TEAM_FOR_PLAYER",
+  "TEAM_FOR_COACH",
+  "COACH_FOR_TEAM",
+];
+
 export interface LFGPost {
   id: GeneratedAlways<number>;
   type: LFGType;

--- a/app/features/lfg/lfg-types.ts
+++ b/app/features/lfg/lfg-types.ts
@@ -121,7 +121,7 @@ export function smallStrToFilter(s: string): LFGFilter | null {
       if (!languagesUnified.some((lang) => lang.code === val)) return null;
       return {
         _tag: "Language",
-        language: val, // Kinda trusting the language I get is good, bad idea.
+        language: val,
       };
     }
     case "pt": {

--- a/app/features/lfg/lfg-types.ts
+++ b/app/features/lfg/lfg-types.ts
@@ -1,6 +1,8 @@
-import type { LFGType } from "~/db/tables";
+import { LFG_TYPES, type LFGType } from "~/db/tables";
 import type { MainWeaponId } from "~/modules/in-game-lists";
 import { TIERS, type TierName } from "../mmr/mmr-constants";
+import { assertUnreachable } from "~/utils/types";
+import { languagesUnified } from "~/modules/i18n/config";
 
 export type LFGFilter =
   | WeaponFilter
@@ -46,12 +48,7 @@ type MinTierFilter = {
   tier: TierName;
 };
 
-const typeToNum: Map<LFGType, number> = new Map([
-  ["PLAYER_FOR_TEAM", 0],
-  ["TEAM_FOR_PLAYER", 1],
-  ["TEAM_FOR_COACH", 2],
-  ["COACH_FOR_TEAM", 3],
-]);
+const typeToNum = new Map(LFG_TYPES.map((tier, index) => [tier, `${index}`]));
 
 const numToType = new Map(
   Array.from(typeToNum).map(([type, num]) => [`${num}`, type]),
@@ -85,6 +82,8 @@ export function filterToSmallStr(filter: LFGFilter): string {
       return `mx.${tierToNum.get(filter.tier)}`;
     case "MinTier":
       return `mn.${tierToNum.get(filter.tier)}`;
+    default:
+      assertUnreachable(filter);
   }
 }
 
@@ -119,6 +118,7 @@ export function smallStrToFilter(s: string): LFGFilter | null {
       };
     }
     case "l": {
+      if (!languagesUnified.some((lang) => lang.code === val)) return null;
       return {
         _tag: "Language",
         language: val, // Kinda trusting the language I get is good, bad idea.

--- a/app/features/lfg/lfg-types.ts
+++ b/app/features/lfg/lfg-types.ts
@@ -1,6 +1,6 @@
-import type { Tables } from "~/db/tables";
+import type { LFGType } from "~/db/tables";
 import type { MainWeaponId } from "~/modules/in-game-lists";
-import type { TierName } from "../mmr/mmr-constants";
+import { TIERS, type TierName } from "../mmr/mmr-constants";
 
 export type LFGFilter =
   | WeaponFilter
@@ -18,7 +18,7 @@ type WeaponFilter = {
 
 type TypeFilter = {
   _tag: "Type";
-  type: Tables["LFGPost"]["type"];
+  type: LFGType;
 };
 
 type TimezoneFilter = {
@@ -45,3 +45,109 @@ type MinTierFilter = {
   _tag: "MinTier";
   tier: TierName;
 };
+
+const typeToNum: Map<LFGType, number> = new Map([
+  ["PLAYER_FOR_TEAM", 0],
+  ["TEAM_FOR_PLAYER", 1],
+  ["TEAM_FOR_COACH", 2],
+  ["COACH_FOR_TEAM", 3],
+]);
+
+const numToType = new Map(
+  Array.from(typeToNum).map(([type, num]) => [`${num}`, type]),
+);
+
+const tierToNum = new Map(
+  TIERS.map((tier, index) => {
+    return [tier.name, `${index}`];
+  }),
+);
+
+const numToTier = new Map(
+  Array.from(tierToNum).map(([tier, num]) => [`${num}`, tier]),
+);
+
+export function filterToSmallStr(filter: LFGFilter): string {
+  switch (filter._tag) {
+    case "Weapon": {
+      const weapons = filter.weaponSplIds.map((wid) => `${wid}`).join(",");
+      return `w.${weapons}`;
+    }
+    case "Type":
+      return `t.${typeToNum.get(filter.type)}`;
+    case "Timezone":
+      return `tz.${filter.maxHourDifference}`;
+    case "Language":
+      return `l.${filter.language}`;
+    case "PlusTier":
+      return `pt.${filter.tier}`;
+    case "MaxTier":
+      return `mx.${tierToNum.get(filter.tier)}`;
+    case "MinTier":
+      return `mn.${tierToNum.get(filter.tier)}`;
+  }
+}
+
+export function smallStrToFilter(s: string): LFGFilter | null {
+  const [tag, val] = s.split(".");
+  switch (tag) {
+    case "w": {
+      const weaponIds = val
+        .split(",")
+        .map((x) => parseInt(x) as MainWeaponId)
+        .filter((x) => x !== null && x !== undefined);
+      if (weaponIds.length === 0) return null;
+      return {
+        _tag: "Weapon",
+        weaponSplIds: weaponIds,
+      };
+    }
+    case "t": {
+      const filterType = numToType.get(val);
+      if (!filterType) return null;
+      return {
+        _tag: "Type",
+        type: filterType,
+      };
+    }
+    case "tz": {
+      const n = parseInt(val);
+      if (Number.isNaN(n)) return null;
+      return {
+        _tag: "Timezone",
+        maxHourDifference: n,
+      };
+    }
+    case "l": {
+      return {
+        _tag: "Language",
+        language: val, // Kinda trusting the language I get is good, bad idea.
+      };
+    }
+    case "pt": {
+      const n = parseInt(val);
+      if (Number.isNaN(n)) return null;
+      return {
+        _tag: "PlusTier",
+        tier: n,
+      };
+    }
+    case "mx": {
+      const tier = numToTier.get(val);
+      if (!tier) return null;
+      return {
+        _tag: "MaxTier",
+        tier: tier,
+      };
+    }
+    case "mn": {
+      const tier = numToTier.get(val);
+      if (!tier) return null;
+      return {
+        _tag: "MinTier",
+        tier: tier,
+      };
+    }
+  }
+  return null;
+}

--- a/app/hooks/useSearchParamState.ts
+++ b/app/hooks/useSearchParamState.ts
@@ -12,7 +12,7 @@ export function useSearchParamState<T>({
   /** Function to revive string from search params to value. If returns a null or undefined value then defaultValue gets used. */
   revive: (value: string) => T | null | undefined;
 }) {
-  useSearchParamStateEncoder({
+  return useSearchParamStateEncoder({
     defaultValue: defaultValue,
     name: name,
     revive: revive,


### PR DESCRIPTION
This completes https://github.com/Sendouc/sendou.ink/issues/1733
Also added support for custom encoder for `useSearchParamState`, this should enable us to avoid having a big json blob on the url bar :p

Demonstration of the code working: https://testing.avillagra.net/lfg?q=l.en-w.0%2C1-mn.1