### PR TITLE
Added twitter's special tags

### DIFF
--- a/app/features/tournament-bracket/core/Tournament.server.ts
+++ b/app/features/tournament-bracket/core/Tournament.server.ts
@@ -3,6 +3,8 @@ import * as TournamentRepository from "~/features/tournament/TournamentRepositor
 import { notFoundIfFalsy } from "~/utils/remix";
 import type { Unwrapped } from "~/utils/types";
 import { getServerTournamentManager } from "./brackets-manager/manager.server";
+import { HACKY_resolvePicture } from "~/features/tournament/tournament-utils";
+import { userSubmittedImage } from "~/utils/urls";
 
 const manager = getServerTournamentManager();
 
@@ -25,11 +27,15 @@ export async function tournamentData({
     ctx.staff.some(
       (staff) => staff.id === user?.id && staff.role === "ORGANIZER",
     );
+  const logo = ctx.logoUrl
+    ? userSubmittedImage(ctx.logoUrl)
+    : HACKY_resolvePicture(ctx);
 
   return {
     data: manager.get.tournamentData(tournamentId),
     ctx: {
       ...ctx,
+      logoSrc: logo,
       teams: ctx.teams.map((team) => {
         const isOwnTeam = team.members.some(
           (member) => member.userId === user?.id,

--- a/app/features/tournament-bracket/core/Tournament.ts
+++ b/app/features/tournament-bracket/core/Tournament.ts
@@ -9,7 +9,6 @@ import { assertUnreachable } from "~/utils/types";
 import { isAdmin } from "~/permissions";
 import { TOURNAMENT } from "~/features/tournament";
 import type { TournamentData, TournamentDataTeam } from "./Tournament.server";
-import { HACKY_resolvePicture } from "~/features/tournament/tournament-utils";
 import { rankedModesShort } from "~/modules/in-game-lists/modes";
 import type { ModeShort } from "~/modules/in-game-lists";
 import {
@@ -483,11 +482,7 @@ export class Tournament {
   }
 
   get logoSrc() {
-    if (this.ctx.logoUrl) {
-      return userSubmittedImage(this.ctx.logoUrl);
-    }
-
-    return HACKY_resolvePicture(this.ctx);
+    return this.ctx.logoSrc;
   }
 
   get modesIncluded(): ModeShort[] {

--- a/app/features/tournament-bracket/core/tests/mocks.ts
+++ b/app/features/tournament-bracket/core/tests/mocks.ts
@@ -2286,6 +2286,7 @@ export const PADDLING_POOL_257 = () =>
         "Hosted by Dapple Productions.\n\nThe longest tournament series in Splatoon!\nEvery week a tournament!\n\n✓ DE or Groups into SE\n✓ All Modes (Picnic system)\n✓ Badge prize\n✓ A well-ran tournament experience\n\nCome join!",
       rules: null,
       logoUrl: null,
+      logoSrc: "/test.png",
       avatarImgId: null,
       startTime: 1709748000,
       author: {
@@ -8132,6 +8133,7 @@ export const PADDLING_POOL_255 = () =>
       description: null,
       rules: null,
       logoUrl: null,
+      logoSrc: "/test.png",
       avatarImgId: null,
       startTime: 1708538400,
       author: {
@@ -14295,6 +14297,7 @@ export const IN_THE_ZONE_32 = () =>
       description: "Part of sendou.ink ranked season 2",
       rules: null,
       logoUrl: null,
+      logoSrc: "/test.png",
       avatarImgId: null,
       startTime: 1707588000,
       author: {

--- a/app/features/tournament-bracket/core/tests/test-utils.ts
+++ b/app/features/tournament-bracket/core/tests/test-utils.ts
@@ -44,6 +44,7 @@ export const testTournament = (
       description: null,
       rules: null,
       logoUrl: null,
+      logoSrc: "/test.png",
       avatarImgId: null,
       discordUrl: null,
       startTime: 1705858842,

--- a/app/features/tournament/routes/to.$id.tsx
+++ b/app/features/tournament/routes/to.$id.tsx
@@ -41,10 +41,12 @@ export const meta: MetaFunction = (args) => {
 
   if (!data) return [];
 
+  const title = makeTitle(data.tournament.ctx.name);
+
   return [
     {
       property: "og:title",
-      content: makeTitle(data.tournament.ctx.name),
+      content: title,
     },
     {
       property: "og:description",
@@ -57,6 +59,19 @@ export const meta: MetaFunction = (args) => {
     {
       property: "og:image",
       content: HACKY_resolvePicture(data.tournament.ctx),
+    },
+    // Twitter special snowflake tags, see https://developer.x.com/en/docs/twitter-for-websites/cards/overview/summary
+    {
+      name: "twitter:card",
+      content: "summary",
+    },
+    {
+      name: "twitter:title",
+      content: title,
+    },
+    {
+      name: "twitter:site",
+      content: "@sendouink",
     },
   ];
 };

--- a/app/features/tournament/routes/to.$id.tsx
+++ b/app/features/tournament/routes/to.$id.tsx
@@ -58,7 +58,7 @@ export const meta: MetaFunction = (args) => {
     },
     {
       property: "og:image",
-      content: HACKY_resolvePicture(data.tournament.ctx),
+      content: data.tournament.ctx.logoSrc,
     },
     // Twitter special snowflake tags, see https://developer.x.com/en/docs/twitter-for-websites/cards/overview/summary
     {


### PR DESCRIPTION
Added Twitter's special tags. They were required for rendering because they are special.

Their docs don't mention anything about renaming `name="twitter:card"` into `name="x:tag"`, let's hope Elon doesn't notice.

Fixes https://github.com/Sendouc/sendou.ink/issues/1741

<img width="600" alt="Screenshot 2024-05-26 at 9 03 53 AM" src="https://github.com/Sendouc/sendou.ink/assets/89531860/c8f48566-d512-48d0-a38a-17b0c5451edc">
