### PR TITLE
Added cursor line rendering to the Build Analyzer chart and fixed .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ TWITCH_CLIENT_SECRET=
 SKALOP_SYSTEM_MESSAGE_URL=http://localhost:5900/system
 SKALOP_TOKEN=secret
 
+BASE_URL=https://example.com
+
 VITE_SITE_DOMAIN=http://localhost:5173
 VITE_SKALOP_WS_URL=ws://localhost:5900
 

--- a/app/components/Chart.tsx
+++ b/app/components/Chart.tsx
@@ -12,7 +12,7 @@ export default function Chart({
 	headerSuffix,
 	valueSuffix,
 	xAxis,
-  renderCursorLines = false,
+	renderCursorLines = false,
 }: {
 	options: [
 		{ label: string; data: Array<{ primary: Date; secondary: number }> },
@@ -21,7 +21,7 @@ export default function Chart({
 	headerSuffix?: string;
 	valueSuffix?: string;
 	xAxis: "linear" | "localTime";
-  renderCursorLines?: boolean;
+	renderCursorLines?: boolean;
 }) {
 	const { i18n } = useTranslation();
 	const theme = useTheme();

--- a/app/components/Chart.tsx
+++ b/app/components/Chart.tsx
@@ -12,6 +12,7 @@ export default function Chart({
 	headerSuffix,
 	valueSuffix,
 	xAxis,
+  renderCursorLines = false
 }: {
 	options: [
 		{ label: string; data: Array<{ primary: Date; secondary: number }> },
@@ -20,6 +21,7 @@ export default function Chart({
 	headerSuffix?: string;
 	valueSuffix?: string;
 	xAxis: "linear" | "localTime";
+  renderCursorLines?: boolean;
 }) {
 	const { i18n } = useTranslation();
 	const theme = useTheme();
@@ -78,8 +80,8 @@ export default function Chart({
 							/>
 						),
 					},
-					primaryCursor: false,
-					secondaryCursor: false,
+					primaryCursor: renderCursorLines,
+					secondaryCursor: renderCursorLines,
 					primaryAxis,
 					secondaryAxes,
 					dark: theme.htmlThemeClass === Theme.DARK,

--- a/app/components/Chart.tsx
+++ b/app/components/Chart.tsx
@@ -12,7 +12,7 @@ export default function Chart({
 	headerSuffix,
 	valueSuffix,
 	xAxis,
-  renderCursorLines = false
+  renderCursorLines = false,
 }: {
 	options: [
 		{ label: string; data: Array<{ primary: Date; secondary: number }> },

--- a/app/features/build-analyzer/routes/analyzer.tsx
+++ b/app/features/build-analyzer/routes/analyzer.tsx
@@ -1025,6 +1025,7 @@ function StatChart({
 			headerSuffix={t("analyzer:abilityPoints.short")}
 			valueSuffix={valueSuffix}
 			xAxis="linear"
+      renderCursorLines
 		/>
 	);
 }

--- a/app/features/build-analyzer/routes/analyzer.tsx
+++ b/app/features/build-analyzer/routes/analyzer.tsx
@@ -1025,7 +1025,7 @@ function StatChart({
 			headerSuffix={t("analyzer:abilityPoints.short")}
 			valueSuffix={valueSuffix}
 			xAxis="linear"
-      renderCursorLines
+			renderCursorLines
 		/>
 	);
 }


### PR DESCRIPTION
Issue Link: https://github.com/Sendouc/sendou.ink/issues/1806

# Description of Changes

Added cursor line rendering to the Build Analyzer chart when a data point is selected (default value for this option is `false` when not specified)
- Also fixed an "Invalid URL" error when following the README instructions & running the application locally (by adding the `BASE_URL` field to `.env.example`)

==

This is how the Build Analyzer chart looks like after the change when hovering over the chart:

![image](https://github.com/user-attachments/assets/0ce97355-66a8-4db3-90fd-016b597df165)
