### PR TITLE
Feat: add custom title for icon

### DIFF
--- a/app/components/icons/Beaker.tsx
+++ b/app/components/icons/Beaker.tsx
@@ -1,4 +1,7 @@
-export function BeakerIcon({ className }: { className?: string }) {
+export function BeakerIcon({
+	className,
+	title,
+}: { className?: string; title?: string }) {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
@@ -8,7 +11,7 @@ export function BeakerIcon({ className }: { className?: string }) {
 			stroke="currentColor"
 			className={className}
 		>
-			<title>Beaker Icon</title>
+			<title>{title ?? "Beaker Icon"}</title>
 			<path
 				strokeLinecap="round"
 				strokeLinejoin="round"

--- a/app/features/build-analyzer/routes/analyzer.tsx
+++ b/app/features/build-analyzer/routes/analyzer.tsx
@@ -968,10 +968,15 @@ interface StatChartProps {
 }
 
 function StatChartPopover(props: StatChartProps) {
+	const { t } = useTranslation(["analyzer"]);
+
 	return (
 		<Popover
 			buttonChildren={
-				<BeakerIcon className="analyzer__stat-popover-trigger__icon" />
+				<BeakerIcon
+					className="analyzer__stat-popover-trigger__icon"
+					title={t("analyzer:button.showChart")}
+				/>
 			}
 			contentClassName="analyzer__stat-popover"
 			triggerClassName={

--- a/locales/en/analyzer.json
+++ b/locales/en/analyzer.json
@@ -159,5 +159,6 @@
 	"noDmgData": "No damage data yet for this weapon. Check back later!",
 	"perInkTankGrid.header_one": "{{weapon}} shots after ×{{count}} sub weapon used",
 	"perInkTankGrid.header_other": "{{weapon}} shots after ×{{count}} sub weapons used",
-	"bigBubblerExplanation": "{{weapon}} duration is also increased as the durability increases"
+	"bigBubblerExplanation": "{{weapon}} duration is also increased as the durability increases",
+	"button.showChart": "Show chart"
 }


### PR DESCRIPTION
## Description

Added an alternative title/tooltip/hover text for the `Beaker` icon to give a better hint of why it's clickable.

This is just a personal preference, feel free to close the PR if you don't like it. Technically, the same change could be applied to all icons.

## Changes

1. Icon props
2. `analyzer.tsx`, pass custom title to the icon
3. Translation

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/3938888b-96fb-4982-a140-e7f5caa81470)

### After 

![image](https://github.com/user-attachments/assets/6ac16988-f904-429e-864b-e7ef32c240c2)
