### PR TITLE
Add splatoon guides repo to links.json

### DIFF
--- a/app/features/links/links.json
+++ b/app/features/links/links.json
@@ -93,5 +93,10 @@
 		"title": "Playing smarter: a guide to improving tactical thinking",
 		"url": "https://zy-f.notion.site/zy-f/playing-smarter-a-guide-to-improving-tactical-thinking-625e307d08f142b6bb97895117365425",
 		"description": "a guide to improving at Splatoon, beyond raw mechanical ability"
+	},
+	{
+		"title": "Splatoon Guides",
+		"url": "https://github.com/tessssaract/guides",
+		"description": "A curated list of resources for captaining teams, weapons, specials, and more"
 	}
 ]


### PR DESCRIPTION
Adds a link to my repo compiling splatoon guides like you suggested on Bluesky