### PR TITLE
Better tournament standings

### DIFF
--- a/app/db/seed/index.ts
+++ b/app/db/seed/index.ts
@@ -1268,7 +1268,7 @@ function calendarEventWithToToolsTeams(
 				});
 		}
 
-		if (Math.random() < 0.8 || id === 1) {
+		if (event !== "SOS" && (Math.random() < 0.8 || id === 1)) {
 			const shuffledPairs = shuffle(availablePairs.slice());
 
 			let SZ = 0;

--- a/app/features/tournament-bracket/components/MatchActionsBanPicker.tsx
+++ b/app/features/tournament-bracket/components/MatchActionsBanPicker.tsx
@@ -174,7 +174,7 @@ function MapPicker({
 							})}
 						</div>
 						{pickersLastWonMode === mode && modes.length > 1 ? (
-							<div className="text-error text-xs text-center">
+							<div className="text-error text-xs text-center mt-2">
 								Can&apos;t pick the same mode team last won on
 							</div>
 						) : null}

--- a/app/features/tournament-bracket/core/Progression.test.ts
+++ b/app/features/tournament-bracket/core/Progression.test.ts
@@ -536,3 +536,47 @@ describe("changedBracketProgression", () => {
 		).toEqual([]);
 	});
 });
+
+describe("bracketIdxsForStandings", () => {
+	it("handles SE", () => {
+		expect(
+			Progression.bracketIdxsForStandings(progressions.singleElimination),
+		).toEqual([0]);
+	});
+
+	it("handles RR->SE", () => {
+		expect(
+			Progression.bracketIdxsForStandings(
+				progressions.roundRobinToSingleElimination,
+			),
+		).toEqual([1, 0]);
+	});
+
+	it("handles low ink", () => {
+		expect(Progression.bracketIdxsForStandings(progressions.lowInk)).toEqual([
+			3, 1,
+			0,
+			// NOTE: 2 is omitted as it's an "intermediate" bracket
+		]);
+	});
+
+	it("handles many starter brackets", () => {
+		expect(
+			Progression.bracketIdxsForStandings(progressions.manyStartBrackets),
+		).toEqual([2, 0]); // NOTE, 3,1 excluded because they are not in the main progression
+	});
+
+	it("handles swiss (one group)", () => {
+		expect(
+			Progression.bracketIdxsForStandings(progressions.swissOneGroup),
+		).toEqual([0]);
+	});
+
+	it("handles DE w/ underground bracket", () => {
+		expect(
+			Progression.bracketIdxsForStandings(
+				progressions.doubleEliminationWithUnderground,
+			),
+		).toEqual([0]); // missing 1 because it's underground when DE is the source
+	});
+});

--- a/app/features/tournament-bracket/core/Tournament.ts
+++ b/app/features/tournament-bracket/core/Tournament.ts
@@ -5,6 +5,7 @@ import type {
 } from "~/db/tables";
 import { TOURNAMENT } from "~/features/tournament";
 import type * as Progression from "~/features/tournament-bracket/core/Progression";
+import * as Standings from "~/features/tournament/core/Standings";
 import { tournamentIsRanked } from "~/features/tournament/tournament-utils";
 import type { TournamentManagerDataSet } from "~/modules/brackets-manager/types";
 import type { Match, Stage } from "~/modules/brackets-model";
@@ -655,46 +656,7 @@ export class Tournament {
 	}
 
 	get standings() {
-		if (this.brackets.length === 1) {
-			return this.brackets[0].standings;
-		}
-
-		for (const bracket of this.brackets) {
-			if (bracket.isFinals) {
-				const finalsStandings = bracket.standings;
-
-				const firstStageStandings = this.brackets[0].standings;
-
-				const uniqueFinalsPlacements = new Set<number>();
-				const firstStageWithoutFinalsParticipants = firstStageStandings.filter(
-					(firstStageStanding) => {
-						const isFinalsParticipant = finalsStandings.some(
-							(finalsStanding) =>
-								finalsStanding.team.id === firstStageStanding.team.id,
-						);
-
-						if (isFinalsParticipant) {
-							uniqueFinalsPlacements.add(firstStageStanding.placement);
-						}
-
-						return !isFinalsParticipant;
-					},
-				);
-
-				return [
-					...finalsStandings,
-					...firstStageWithoutFinalsParticipants.filter(
-						// handle edge case where teams didn't check in to the final stage despite being qualified
-						// although this would bug out if all teams of certain placement fail to check in
-						// but probably that should not happen too likely
-						(p) => !uniqueFinalsPlacements.has(p.placement),
-					),
-				];
-			}
-		}
-
-		logger.warn("Standings not found");
-		return [];
+		return Standings.tournamentStandings(this);
 	}
 
 	canFinalize(user: OptionalIdObject) {

--- a/app/features/tournament-bracket/core/tests/test-utils.ts
+++ b/app/features/tournament-bracket/core/tests/test-utils.ts
@@ -262,4 +262,21 @@ export const progressions = {
 			},
 		},
 	],
+	doubleEliminationWithUnderground: [
+		{
+			...DEFAULT_PROGRESSION_ARGS,
+			type: "double_elimination",
+		},
+		{
+			...DEFAULT_PROGRESSION_ARGS,
+			type: "double_elimination",
+			name: "Underground",
+			sources: [
+				{
+					bracketIdx: 0,
+					placements: [-1, -2],
+				},
+			],
+		},
+	],
 } satisfies Record<string, Progression.ParsedBracket[]>;

--- a/app/features/tournament-bracket/routes/to.$id.brackets.tsx
+++ b/app/features/tournament-bracket/routes/to.$id.brackets.tsx
@@ -688,7 +688,15 @@ function BracketNav({
 }) {
 	const tournament = useTournament();
 
-	if (tournament.ctx.settings.bracketProgression.length < 2) return null;
+	const shouldRender = () => {
+		const brackets = tournament.ctx.isFinalized
+			? tournament.brackets.filter((b) => !b.preview)
+			: tournament.ctx.settings.bracketProgression;
+
+		return brackets.length > 1;
+	};
+
+	if (!shouldRender()) return null;
 
 	const visibleBrackets = tournament.ctx.settings.bracketProgression.filter(
 		// an underground bracket was never played despite being in the format

--- a/app/features/tournament/routes/to.$id.results.tsx
+++ b/app/features/tournament/routes/to.$id.results.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@remix-run/react";
 import clsx from "clsx";
+import * as React from "react";
 import { Avatar } from "~/components/Avatar";
 import { Flag } from "~/components/Flag";
 import { InfoPopover } from "~/components/InfoPopover";
@@ -143,15 +144,19 @@ function MatchHistoryRow({ teamId }: { teamId: number }) {
 
 	return (
 		<div className="stack horizontal xs">
-			{teamMatches.map((match) => {
+			{teamMatches.map((match, i) => {
+				const bracketChanged =
+					i !== 0 && teamMatches[i - 1].bracketIdx !== match.bracketIdx;
+
 				return (
-					<MatchResultSquare
-						key={match.id}
-						result={match.result}
-						matchId={match.id}
-					>
-						{match.vsSeed}
-					</MatchResultSquare>
+					<React.Fragment key={match.id}>
+						{bracketChanged ? (
+							<div className="tournament__standings__divider" />
+						) : null}
+						<MatchResultSquare result={match.result} matchId={match.id}>
+							{match.vsSeed}
+						</MatchResultSquare>
+					</React.Fragment>
 				);
 			})}
 		</div>

--- a/app/features/tournament/tournament.css
+++ b/app/features/tournament/tournament.css
@@ -637,3 +637,9 @@
 	align-items: center;
 	color: var(--text);
 }
+
+.tournament__standings__divider {
+	width: 5px;
+	background-color: var(--theme-transparent);
+	border-radius: var(--rounded);
+}


### PR DESCRIPTION
Take in account more brackets than just the "main route".

Also show more matches on the results page, brackets separated.

## Old

<img width="777" alt="image" src="https://github.com/user-attachments/assets/faca969a-667a-4244-90c3-b961c50daa24">

## New

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/32a2c0f4-fdd5-4379-84c9-d16002dbd38c">
