### PR TITLE
Stringer Max Booyah Damage Fix

### DIFF
--- a/app/features/object-damage-calculator/core/objectDamage.ts
+++ b/app/features/object-damage-calculator/core/objectDamage.ts
@@ -258,9 +258,18 @@ export function calculateDamage({
 					}
 
 					const otherDamage = () => {
+						//[Special Case] Booyah ignores Tri-Stringer's otherDamage at full charge. In-game bug
+						if (
+							[7010, 7011].includes(anyWeapon.id) &&
+							receiver === "NiceBall_Armor"
+						) {
+							return 0;
+						}
+
 						const result = filteredDamages.find(
 							(damage) => damage.type === toCombine?.combineWith,
 						)?.value;
+
 						invariant(result);
 
 						return result;


### PR DESCRIPTION
Proposed solution to Issue #1544 

Added a special case to the "otherDamage()" function that returns 0 if the weapon is Tri-Stringer and the special is Booyah. Let me know if there are any changes I should make to the implementation, thanks!

To test, run the development build, navigate to the Damage Calculator, and select Tri-Stringer/Inkline Tri-Stringer. The intended result is 136.5 DMG and 4 HTD in the "maximum" damage type, with the others being unaffected. 



