### PR TITLE
Changed Name of Original Message Deleted badge

### DIFF
--- a/app/features/badges/homemade.ts
+++ b/app/features/badges/homemade.ts
@@ -335,7 +335,7 @@ export const homemadeBadges: BadgeInfo[] = [
 		authorDiscordId: "342369454719631361",
 	},
 	{
-		displayName: "Original Message Deleted",
+		displayName: "[Original Message Deleted]",
 		fileName: "original-message-deleted",
 		authorDiscordId: "751912670403362836",
 	},


### PR DESCRIPTION
Changed the name of "Original Message Deleted" badge to "[Original Message Deleted]"