### PR TITLE
Fix switch styling

### DIFF
--- a/app/styles/elements.css
+++ b/app/styles/elements.css
@@ -137,7 +137,8 @@
 }
 
 .react-aria-Switch {
-	display: flex;
+	display: grid;
+	grid-template-columns: auto 1fr;
 	align-items: center;
 	gap: 0.571rem;
 	color: var(--text-color);


### PR DESCRIPTION
Prevent switch from shrinking when label is too large. Just some flex weirdness, switched to grid instead.

Closes #2161

