### PR TITLE
Make nav fixed again

### DIFF
--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -58,6 +58,9 @@
 	font-weight: bold;
 	padding-block: var(--s-2);
 	padding-inline: var(--s-4);
+	position: fixed;
+	top: 0;
+	z-index: 10;
 }
 
 .layout__avatar {
@@ -152,6 +155,7 @@
 .layout__main-container {
 	display: flex;
 	flex-direction: row;
+	padding-top: 80px;
 }
 
 .layout__main {


### PR DESCRIPTION
This PR makes the navbar fixed again

Note that we can not use sticky anymore, as the dropdown component adds ``overflow: hidden;`` to the html, which makes the navbar stick to the top of the page

Closes #2163 