### PR TITLE
Prevent pagination from weird overflow

### DIFF
--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -18,7 +18,7 @@ export function Pagination({
 	setPage: (page: number) => void;
 }) {
 	return (
-		<div className="stack sm horizontal items-center justify-center flex-wrap">
+		<div className="pagination__container">
 			<Button
 				icon={<ArrowLeftIcon />}
 				variant="outlined"
@@ -27,15 +27,17 @@ export function Pagination({
 				onClick={previousPage}
 				aria-label="Previous page"
 			/>
-			{nullFilledArray(pagesCount).map((_, i) => (
-				<div
-					key={i}
-					className={clsx("pagination__dot", {
-						pagination__dot__active: i === currentPage - 1,
-					})}
-					onClick={() => setPage(i + 1)}
-				/>
-			))}
+			<div className="pagination__dots">
+				{nullFilledArray(pagesCount).map((_, i) => (
+					<div
+						key={i}
+						className={clsx("pagination__dot", {
+							pagination__dot__active: i === currentPage - 1,
+						})}
+						onClick={() => setPage(i + 1)}
+					/>
+				))}
+			</div>
 			<div className="pagination__page-count">
 				{currentPage}/{pagesCount}
 			</div>

--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -1481,10 +1481,6 @@ html[dir="rtl"] .fix-rtl {
 }
 
 @media screen and (min-width: 640px) {
-	.pagination__container {
-		grid-template-columns: auto 1fr auto;
-	}
-
 	.pagination__dots {
 		display: flex;
 	}

--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -1445,13 +1445,29 @@ html[dir="rtl"] .fix-rtl {
 	transform: rotate(180deg);
 }
 
+.pagination__container {
+	display: grid;
+	grid-template-columns: auto auto auto;
+	gap: var(--s-2);
+	align-items: center;
+	justify-items: center;
+	justify-content: center;
+}
+
+.pagination__dots {
+	display: none;
+	align-items: center;
+	justify-content: center;
+	gap: var(--s-1);
+	flex-wrap: wrap;
+}
+
 .pagination__dot {
 	width: 0.6rem;
 	height: 0.6rem;
 	border-radius: 50%;
 	background-color: var(--theme-transparent);
 	transition: all 0.2s ease;
-	display: none;
 }
 
 .pagination__dot__active {
@@ -1465,8 +1481,12 @@ html[dir="rtl"] .fix-rtl {
 }
 
 @media screen and (min-width: 640px) {
-	.pagination__dot {
-		display: initial;
+	.pagination__container {
+		grid-template-columns: auto 1fr auto;
+	}
+
+	.pagination__dots {
+		display: flex;
 	}
 
 	.pagination__page-count {


### PR DESCRIPTION
This PR updates the pagination to prevent it from overflowing weirdly with too many items

Closes #1637 

Desktop view
![chrome_Cjv21tYBk8](https://github.com/user-attachments/assets/98112883-4a2f-401f-b4d8-a19800bba148)

Mobile view remains the same
![chrome_xJMv8el9Yn](https://github.com/user-attachments/assets/c9427031-58e3-4ed0-8af1-c59491df7fa5)
