### PR TITLE
Matckmaking UI

### DIFF
--- a/app/features/sendouq/components/GroupCard.tsx
+++ b/app/features/sendouq/components/GroupCard.tsx
@@ -160,22 +160,26 @@ export function GroupCard({
 					</div>
 				) : null}
 				{group.tierRange?.range ? (
-					<div className="stack sm items-center">
-						<div className="q__group__tier-diff-text">
-							±{group.tierRange.diff}
+					<div className="stack items-center xs">
+						<div className="q__group__display-group-range font-bold">
+							<TierImage tier={group.tierRange.range[0]} width={80} />
+							{t("q:looking.range.or")}
+							<TierImage tier={group.tierRange.range[1]} width={80} />
+							<span className="text-lighter text-xs">
+								{group.tierRange.range[0].name}
+								{group.tierRange.range[0].isPlus ? "+" : ""}
+							</span>
+							<span />
+							<span className="text-lighter text-xs">
+								{group.tierRange.range[1].name}
+								{group.tierRange.range[1].isPlus ? "+" : ""}
+							</span>
 						</div>
-						<div className="stack items-center">
-							<div className="stack sm horizontal items-center text-sm font-bold">
-								<TierImage tier={group.tierRange.range[0]} width={38} />
-								{t("q:looking.range.or")}
-								<TierImage tier={group.tierRange.range[1]} width={38} />
+						{!group.isReplay ? (
+							<div className="text-theme-secondary text-uppercase text-xs font-bold">
+								{t("q:looking.replay")}
 							</div>
-							{group.isReplay ? (
-								<div className="text-theme-secondary text-uppercase text-xs font-bold">
-									{t("q:looking.replay")}
-								</div>
-							) : null}
-						</div>
+						) : null}
 					</div>
 				) : null}
 				{group.skillDifference ? (

--- a/app/features/sendouq/components/GroupCard.tsx
+++ b/app/features/sendouq/components/GroupCard.tsx
@@ -175,7 +175,7 @@ export function GroupCard({
 								{group.tierRange.range[1].isPlus ? "+" : ""}
 							</span>
 						</div>
-						{!group.isReplay ? (
+						{group.isReplay ? (
 							<div className="text-theme-secondary text-uppercase text-xs font-bold">
 								{t("q:looking.replay")}
 							</div>

--- a/app/features/sendouq/q.css
+++ b/app/features/sendouq/q.css
@@ -319,8 +319,13 @@
 	transform: translate(-50%, -50%);
 }
 
-.q__group__tier-diff-text {
-	font-size: 3rem;
+.q__group__display-group-range {
+	display: grid;
+	grid-template-columns: 1fr auto 1fr;
+	grid-template-rows: 1fr auto;
+	align-items: center;
+	justify-items: center;
+	column-gap: var(--s-2);
 }
 
 .q__member-adder__input {


### PR DESCRIPTION
This PR updates the UI of the groups displayed in Q to hopefully make it clearer to end users. 

Closes #2307 

Instead of a +- we now just display the two possible ranks

![chrome_RZPRaMXjEi](https://github.com/user-attachments/assets/db46206a-02fb-4458-806a-58f856c3ba9e)
