### PR TITLE
Add title to flags so that hovering shows country name

### DIFF
--- a/app/components/Flag.tsx
+++ b/app/components/Flag.tsx
@@ -13,6 +13,7 @@ export function Flag({
 				"twf-s": tiny,
 			})}
 			data-testid={`flag-${countryCode}`}
+			title={new Intl.DisplayNames(["en"], { type: "region" }).of(countryCode)}
 		/>
 	);
 }


### PR DESCRIPTION
- I never recognize the flags so I thought it'd be useful to be able to hover over it and see the name.
- I tried using the user's language for localization, instead of displaying directly in English, but I found it tricky to get the information.
- No dependencies introduced.
- I don't think this requires any testing other running `npm run dev` and going to a profile.