### PR TITLE
Single fetch future flag

### DIFF
--- a/app/features/api-private/routes/patrons.ts
+++ b/app/features/api-private/routes/patrons.ts
@@ -13,7 +13,7 @@ export const action: ActionFunction = async ({ request }) => {
 
 	await updatePatreonData();
 
-	return null;
+	return new Response(null, { status: 204 });
 };
 
 export const loader = ({ request }: LoaderFunctionArgs) => {

--- a/app/features/api-private/routes/seed.ts
+++ b/app/features/api-private/routes/seed.ts
@@ -31,5 +31,5 @@ export const action: ActionFunction = async ({ request }) => {
 
 	await seed(variation);
 
-	return null;
+	return new Response(null, { status: 204 });
 };

--- a/app/features/api-private/routes/users.ts
+++ b/app/features/api-private/routes/users.ts
@@ -10,5 +10,5 @@ export const action: ActionFunction = async ({ request }) => {
 	// input untyped but we trust Lohi to give us correctly shaped request here
 	UserRepository.updateMany(await request.json());
 
-	return null;
+	return new Response(null, { status: 204 });
 };

--- a/app/features/api-public/routes/calendar.$year.$week.ts
+++ b/app/features/api-public/routes/calendar.$year.$week.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
 import { db } from "~/db/sql";
@@ -39,7 +39,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 			: null,
 	}));
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };
 
 function fetchEventsOfWeek(args: { week: number; year: number }) {

--- a/app/features/api-public/routes/org.$id.ts
+++ b/app/features/api-public/routes/org.$id.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { jsonArrayFrom } from "kysely/helpers/sqlite";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
@@ -73,5 +73,5 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 		})),
 	};
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };

--- a/app/features/api-public/routes/sendouq.active-match.$userId.ts
+++ b/app/features/api-public/routes/sendouq.active-match.$userId.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
 import { findCurrentGroupByUserId } from "~/features/sendouq/queries/findCurrentGroupByUserId.server";
@@ -29,5 +29,5 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 		matchId: current?.matchId ?? null,
 	};
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };

--- a/app/features/api-public/routes/sendouq.match.$matchId.ts
+++ b/app/features/api-public/routes/sendouq.match.$matchId.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
 import * as QMatchRepository from "~/features/sendouq-match/QMatchRepository.server";
@@ -97,5 +97,5 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 		},
 	};
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };

--- a/app/features/api-public/routes/tournament-match.$id.ts
+++ b/app/features/api-public/routes/tournament-match.$id.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { jsonArrayFrom } from "kysely/helpers/sqlite";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
@@ -172,5 +172,5 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 		roundName: roundNameWithoutMatchIdentifier ?? null,
 	};
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };

--- a/app/features/api-public/routes/tournament.$id.brackets.$bidx.standings.ts
+++ b/app/features/api-public/routes/tournament.$id.brackets.$bidx.standings.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
 import { tournamentFromDB } from "~/features/tournament-bracket/core/Tournament.server";
@@ -37,5 +37,5 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 		})),
 	};
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };

--- a/app/features/api-public/routes/tournament.$id.brackets.$bidx.ts
+++ b/app/features/api-public/routes/tournament.$id.brackets.$bidx.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
 import type { Bracket } from "~/features/tournament-bracket/core/Bracket";
@@ -51,7 +51,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 		},
 	};
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };
 
 function teams(bracket: Bracket) {

--- a/app/features/api-public/routes/tournament.$id.casted.ts
+++ b/app/features/api-public/routes/tournament.$id.casted.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
 import { db } from "~/db/sql";
@@ -47,5 +47,5 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 			})) ?? [],
 	};
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };

--- a/app/features/api-public/routes/tournament.$id.teams.ts
+++ b/app/features/api-public/routes/tournament.$id.teams.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { jsonArrayFrom, jsonObjectFrom } from "kysely/helpers/sqlite";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
@@ -169,7 +169,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 		};
 	});
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };
 
 function toSeedingPowerSP(ordinals: (number | null)[]) {

--- a/app/features/api-public/routes/tournament.$id.ts
+++ b/app/features/api-public/routes/tournament.$id.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { jsonArrayFrom } from "kysely/helpers/sqlite";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
@@ -88,5 +88,5 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 		isFinalized: Boolean(tournament.isFinalized),
 	};
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };

--- a/app/features/api-public/routes/user.$identifier.ts
+++ b/app/features/api-public/routes/user.$identifier.ts
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { jsonArrayFrom } from "kysely/helpers/sqlite";
 import { cors } from "remix-utils/cors";
 import { z } from "zod";
@@ -118,5 +118,5 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 		})),
 	};
 
-	return await cors(request, json(result));
+	return await cors(request, Response.json(result));
 };

--- a/app/features/front-page/routes/patrons-list.ts
+++ b/app/features/front-page/routes/patrons-list.ts
@@ -1,11 +1,12 @@
-import type { SerializeFrom } from "@remix-run/node";
-import { json } from "@remix-run/node";
 import * as UserRepository from "~/features/user-page/UserRepository.server";
+import type { Unwrapped } from "../../../utils/types";
 
-export type PatronsListLoaderData = SerializeFrom<typeof loader>;
+export type PatronsListLoaderData = {
+	patrons: Array<Unwrapped<typeof UserRepository.findAllPatrons>>;
+};
 
 export const loader = async () => {
-	return json(
+	return Response.json(
 		{
 			patrons: await UserRepository.findAllPatrons(),
 		},

--- a/app/features/leaderboards/core/leaderboards.server.ts
+++ b/app/features/leaderboards/core/leaderboards.server.ts
@@ -43,7 +43,7 @@ export async function cachedFullUserLeaderboard(season: number) {
 	});
 }
 
-function addTiers(entries: UserSPLeaderboardItem[], season: number) {
+function addTiers<T extends { id: number }>(entries: T[], season: number) {
 	const tiers = freshUserSkills(season);
 
 	const encounteredTiers = new Set<string>();
@@ -149,7 +149,7 @@ export function ownEntryPeek({
 	userId,
 	season,
 }: {
-	leaderboard: UserSPLeaderboardItem[];
+	leaderboard: UserLeaderboardWithAdditionsItem[];
 	userId: number;
 	season: number;
 }) {

--- a/app/features/leaderboards/routes/leaderboards.tsx
+++ b/app/features/leaderboards/routes/leaderboards.tsx
@@ -235,7 +235,7 @@ function OwnEntryPeek({
 	entry,
 	nextTier,
 }: {
-	entry: NonNullable<SerializeFrom<typeof loader>["userLeaderboard"]>[number];
+	entry: NonNullable<SerializeFrom<typeof loader>["ownEntryPeek"]>["entry"];
 	nextTier?: SkillTierInterval;
 }) {
 	const data = useLoaderData<typeof loader>();

--- a/app/features/theme/routes/theme.ts
+++ b/app/features/theme/routes/theme.ts
@@ -1,7 +1,7 @@
 import {
 	type ActionFunction,
 	type LoaderFunction,
-	json,
+	data,
 	redirect,
 } from "@remix-run/node";
 import { isTheme } from "../core/provider";
@@ -14,21 +14,21 @@ export const action: ActionFunction = async ({ request }) => {
 	const theme = form.get("theme");
 
 	if (theme === "auto") {
-		return json(
+		return data(
 			{ success: true },
 			{ headers: { "Set-Cookie": await themeSession.destroy() } },
 		);
 	}
 
 	if (!isTheme(theme)) {
-		return json({
+		return {
 			success: false,
 			message: `theme value of ${theme ?? "null"} is not a valid theme`,
-		});
+		};
 	}
 
 	themeSession.setTheme(theme);
-	return json(
+	return data(
 		{ success: true },
 		{ headers: { "Set-Cookie": await themeSession.commit() } },
 	);

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -3,7 +3,7 @@ import type {
 	MetaFunction,
 	SerializeFrom,
 } from "@remix-run/node";
-import { json, redirect } from "@remix-run/node";
+import { data, redirect } from "@remix-run/node";
 import {
 	Links,
 	Meta,
@@ -97,7 +97,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 		return redirect(SUSPENDED_PAGE);
 	}
 
-	return json(
+	return data(
 		{
 			locale,
 			theme: themeSession.getTheme(),

--- a/app/utils/playwright.ts
+++ b/app/utils/playwright.ts
@@ -93,13 +93,6 @@ export function modalClickConfirmButton(page: Page) {
 	return page.getByTestId("confirm-button").click();
 }
 
-export async function fetchSendouInk<T>(url: string) {
-	const res = await fetch(`http://localhost:5173${url}`);
-	if (!res.ok) throw new Error("Response not successful");
-
-	return res.json() as T;
-}
-
 export const startBracket = async (page: Page, tournamentId = 2) => {
 	await seed(page);
 	await impersonate(page);

--- a/app/utils/remix.server.ts
+++ b/app/utils/remix.server.ts
@@ -1,4 +1,4 @@
-import { json, redirect } from "@remix-run/node";
+import { data, redirect } from "@remix-run/node";
 import {
 	unstable_composeUploadHandlers as composeUploadHandlers,
 	unstable_createMemoryUploadHandler as createMemoryUploadHandler,
@@ -264,8 +264,8 @@ export type SendouRouteHandle = {
  * To be used when the response is different for each user. This is especially useful when the response
  * is prefetched on link hover.
  */
-export function privatelyCachedJson<T>(data: T) {
-	return json(data, {
+export function privatelyCachedJson<T>(json: T) {
+	return data(json, {
 		headers: { "Cache-Control": "private, max-age=5" },
 	});
 }

--- a/e2e/tournament.spec.ts
+++ b/e2e/tournament.spec.ts
@@ -2,12 +2,10 @@ import { expect, test } from "@playwright/test";
 import { NZAP_TEST_ID } from "~/db/seed/constants";
 import { ADMIN_ID } from "~/features/admin/admin-constants";
 import { BANNED_MAPS } from "~/features/sendouq-settings/banned-maps";
-import type { TournamentLoaderData } from "~/features/tournament/loaders/to.$id.server";
 import { rankedModesShort } from "~/modules/in-game-lists/modes";
 import type { StageId } from "~/modules/in-game-lists/types";
 import invariant from "~/utils/invariant";
 import {
-	fetchSendouInk,
 	impersonate,
 	isNotVisible,
 	navigate,
@@ -16,35 +14,41 @@ import {
 	submit,
 } from "~/utils/playwright";
 import { tournamentBracketsPage, tournamentPage } from "~/utils/urls";
+import { tournamentFromDB } from "../app/features/tournament-bracket/core/Tournament.server";
 
 const fetchTournamentLoaderData = () =>
-	fetchSendouInk<TournamentLoaderData>(
-		"/to/1/admin?_data=features%2Ftournament%2Froutes%2Fto.%24id",
-	);
+	tournamentFromDB({ tournamentId: 1, user: { id: ADMIN_ID } });
 
 const getIsOwnerOfUser = ({
-	data,
+	teams,
 	userId,
 	teamId,
 }: {
-	data: TournamentLoaderData;
+	teams: Array<{
+		id: number;
+		members: Array<{ userId: number; isOwner: number }>;
+	}>;
 	userId: number;
 	teamId: number;
 }) => {
-	const team = data.tournament.ctx.teams.find((t) => t.id === teamId);
+	const team = teams.find((t) => t.id === teamId);
 	invariant(team, "Team not found");
 
 	return team.members.find((m) => m.userId === userId)?.isOwner;
 };
 
 const getTeamCheckedInAt = ({
-	data,
+	teams,
 	teamId,
 }: {
-	data: TournamentLoaderData;
+	teams: Array<{
+		id: number;
+		checkIns: unknown[];
+		members: Array<{ userId: number }>;
+	}>;
 	teamId: number;
 }) => {
-	const team = data.tournament.ctx.teams.find((t) => t.id === teamId);
+	const team = teams.find((t) => t.id === teamId);
 	invariant(team, "Team not found");
 	return team.checkIns.length > 0;
 };
@@ -128,43 +132,67 @@ test.describe("Tournament", () => {
 			await page.getByLabel("Team name").fill("NSTC");
 			await submit(page);
 
-			const data = await fetchTournamentLoaderData();
-			const firstTeam = data.tournament.ctx.teams.find((t) => t.id === 1);
+			const tournament = await fetchTournamentLoaderData();
+			const firstTeam = tournament.ctx.teams.find((t) => t.id === 1);
 			invariant(firstTeam, "First team not found");
 			expect(firstTeam.name).toBe("NSTC");
 		}
 
 		// Change team owner
-		let data = await fetchTournamentLoaderData();
-		expect(getIsOwnerOfUser({ data, userId: ADMIN_ID, teamId: 1 })).toBe(1);
+		let tournament = await fetchTournamentLoaderData();
+		expect(
+			getIsOwnerOfUser({
+				teams: tournament.ctx.teams,
+				userId: ADMIN_ID,
+				teamId: 1,
+			}),
+		).toBe(1);
 
 		await actionSelect.selectOption("CHANGE_TEAM_OWNER");
 		await teamSelect.selectOption("1");
 		await memberSelect.selectOption("2");
 		await submit(page);
 
-		data = await fetchTournamentLoaderData();
-		expect(getIsOwnerOfUser({ data, userId: ADMIN_ID, teamId: 1 })).toBe(0);
-		expect(getIsOwnerOfUser({ data, userId: NZAP_TEST_ID, teamId: 1 })).toBe(1);
+		tournament = await fetchTournamentLoaderData();
+		expect(
+			getIsOwnerOfUser({
+				teams: tournament.ctx.teams,
+				userId: ADMIN_ID,
+				teamId: 1,
+			}),
+		).toBe(0);
+		expect(
+			getIsOwnerOfUser({
+				teams: tournament.ctx.teams,
+				userId: NZAP_TEST_ID,
+				teamId: 1,
+			}),
+		).toBe(1);
 
 		// Check in team
-		expect(getTeamCheckedInAt({ data, teamId: 1 })).toBeFalsy();
+		expect(
+			getTeamCheckedInAt({ teams: tournament.ctx.teams, teamId: 1 }),
+		).toBeFalsy();
 
 		await actionSelect.selectOption("CHECK_IN");
 		await submit(page);
 
-		data = await fetchTournamentLoaderData();
-		expect(getTeamCheckedInAt({ data, teamId: 1 })).toBeTruthy();
+		tournament = await fetchTournamentLoaderData();
+		expect(
+			getTeamCheckedInAt({ teams: tournament.ctx.teams, teamId: 1 }),
+		).toBeTruthy();
 
 		// Check out team
 		await actionSelect.selectOption("CHECK_OUT");
 		await submit(page);
 
-		data = await fetchTournamentLoaderData();
-		expect(getTeamCheckedInAt({ data, teamId: 1 })).toBeFalsy();
+		tournament = await fetchTournamentLoaderData();
+		expect(
+			getTeamCheckedInAt({ teams: tournament.ctx.teams, teamId: 1 }),
+		).toBeFalsy();
 
 		// Remove member...
-		const firstTeam = data.tournament.ctx.teams.find((t) => t.id === 1);
+		const firstTeam = tournament.ctx.teams.find((t) => t.id === 1);
 		invariant(firstTeam, "First team not found");
 		const firstNonOwnerMember = firstTeam.members.find(
 			(m) => m.userId !== 1 && !m.isOwner,
@@ -175,13 +203,13 @@ test.describe("Tournament", () => {
 		await memberSelect.selectOption(String(firstNonOwnerMember.userId));
 		await submit(page);
 
-		data = await fetchTournamentLoaderData();
-		const firstTeamAgain = data.tournament.ctx.teams.find((t) => t.id === 1);
+		tournament = await fetchTournamentLoaderData();
+		const firstTeamAgain = tournament.ctx.teams.find((t) => t.id === 1);
 		invariant(firstTeamAgain, "First team again not found");
 		expect(firstTeamAgain.members.length).toBe(firstTeam.members.length - 1);
 
 		// ...and add to another team
-		const teamWithSpace = data.tournament.ctx.teams.find(
+		const teamWithSpace = tournament.ctx.teams.find(
 			(t) => t.id !== 1 && t.members.length === 4,
 		);
 		invariant(teamWithSpace, "Team with space not found");
@@ -195,8 +223,8 @@ test.describe("Tournament", () => {
 		});
 		await submit(page);
 
-		data = await fetchTournamentLoaderData();
-		const teamWithSpaceAgain = data.tournament.ctx.teams.find(
+		tournament = await fetchTournamentLoaderData();
+		const teamWithSpaceAgain = tournament.ctx.teams.find(
 			(t) => t.id === teamWithSpace.id,
 		);
 		invariant(teamWithSpaceAgain, "Team with space again not found");
@@ -210,8 +238,8 @@ test.describe("Tournament", () => {
 		await teamSelect.selectOption("1");
 		await submit(page);
 
-		data = await fetchTournamentLoaderData();
-		expect(data.tournament.ctx.teams.find((t) => t.id === 1)).toBeFalsy();
+		tournament = await fetchTournamentLoaderData();
+		expect(tournament.ctx.teams.find((t) => t.id === 1)).toBeFalsy();
 	});
 
 	test("adjusts seeds", async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"biome:fix:unsafe": "npx @biomejs/biome check --write --unsafe .",
 		"typecheck": "tsc --noEmit",
 		"test:unit": "cross-env VITE_SITE_DOMAIN=http://localhost:5173 vitest --silent=passed-only run",
-		"test:e2e": "npx playwright test",
+		"test:e2e": "cross-env DB_PATH=db.sqlite3 npx playwright test",
 		"test:e2e:flaky-detect": "npx playwright test --repeat-each=10 --max-failures=1",
 		"checks": "npm run biome:fix && npm run test:unit && npm run check-translation-jsons && npm run typecheck",
 		"setup": "cross-env DB_PATH=db.sqlite3 tsx ./scripts/setup.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,4 @@
 import { vitePlugin as remix } from "@remix-run/dev";
-import { installGlobals } from "@remix-run/node";
 import { defineConfig } from "vite";
 import babel from "vite-plugin-babel";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -10,8 +9,6 @@ declare module "@remix-run/node" {
 		v3_singleFetch: true;
 	}
 }
-
-installGlobals();
 
 const ReactCompilerConfig = {
 	target: "18",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,12 @@ import babel from "vite-plugin-babel";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { configDefaults } from "vitest/config";
 
+declare module "@remix-run/node" {
+	interface Future {
+		v3_singleFetch: true;
+	}
+}
+
 installGlobals();
 
 const ReactCompilerConfig = {
@@ -26,6 +32,7 @@ export default defineConfig(() => {
 					v3_throwAbortReason: true,
 					v3_routeConfig: true,
 					v3_lazyRouteDiscovery: true,
+					v3_singleFetch: true,
 				},
 			}),
 			babel({


### PR DESCRIPTION
Passes tests + e2e tests.

Biggest question is performance impact. For example tournament with ID 1396 is only around 260 avg RPM throughput when the old one was 735. Might still just try it in production and see what happens.

Progress on issue http://github.com/Sendouc/sendou.ink/issues/2281