### PR TITLE
Add CSS rule `touch-action: manipulation` to ability selector

### DIFF
--- a/app/styles/common.css
+++ b/app/styles/common.css
@@ -1219,6 +1219,7 @@ abbr[title] {
 	flex-wrap: wrap;
 	justify-content: center;
 	gap: var(--s-1);
+	touch-action: manipulation;
 }
 
 .ability-selector__ability-button {


### PR DESCRIPTION
I was trying to analyze an Ink Saver only build on the [build analyzer page](https://sendou.ink/analyzer) on a phone. 
Tapping the ability button twice will zoom in the page instead of selecting the ability twice. This behavior is a bit strange and can be fixed with a [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) CSS rule.