### PR TITLE
Increase tournament organization max name length

### DIFF
--- a/app/features/tournament-organization/tournament-organization-schemas.ts
+++ b/app/features/tournament-organization/tournament-organization-schemas.ts
@@ -14,7 +14,7 @@ export const organizationEditSchema = z.object({
 		.string()
 		.trim()
 		.min(2)
-		.max(32)
+		.max(64)
 		.refine((val) => mySlugify(val).length >= 2, {
 			message: "Not enough non-special characters",
 		}),


### PR DESCRIPTION
Increases the character limit on an organization's name from 32 -> 64 characters. 64 is chosen to follow the 2^n pattern from 32
