### PR TITLE
Replace tessssaract/guides in /links with Sunken Scrolls

### DIFF
--- a/app/features/links/links.json
+++ b/app/features/links/links.json
@@ -95,8 +95,8 @@
 		"description": "a guide to improving at Splatoon, beyond raw mechanical ability"
 	},
 	{
-		"title": "Splatoon Guides",
-		"url": "https://github.com/tessssaract/guides",
-		"description": "a curated list of resources for captaining teams, weapons, specials, and more"
+		"title": "Sunken scrolls",
+		"url": "https://scrolls.tessaract.gay/",
+		"description": "an archive for Splatoon guides that would otherwise be lost to time"
 	}
 ]


### PR DESCRIPTION
Sunken Scrolls is my site replacing my previous Github repo listing various links/resources. tessssaract/guides is archived and no longer being updated.

https://scrolls.tessaract.gay/
https://gitlab.com/wellstring/sunken-scrolls