### PR TITLE
Stronghold Article: The Splatoon 3 North American League Playoffs RECAP

### DIFF
--- a/content/articles/splatoon-3-na-league-playoffs.md
+++ b/content/articles/splatoon-3-na-league-playoffs.md
@@ -1,0 +1,94 @@
+---
+title: "The Splatoon 3 North American League Playoffs RECAP"
+date: 2025-12-16
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+# **The Splatoon 3 North American League Playoffs RECAP**
+
+### *The culmination of ten weeks of nonstop Splatoon action ends with one weekend of fierce competition*
+
+<img width="1200" height="675" alt="splatoon-3-na-league-playoffs" src="https://github.com/user-attachments/assets/f273be6f-359a-4285-8f81-50b174a920e9" />
+
+On December 13 and 14, 2025, the Splatoon 3 North American League reached its peak, and the ride to the end was full of twists that kept everyone on the edge of their seat. Unlike the Preseason and Regular Season Top 8s, *every single set* was on stream, making sure each team had their time in the spotlight. 
+
+Jordan, Lily, and Nine commentated for Winner’s Quarterfinals on day 1 and Winner’s Finals through Grand Finals on day 2\. Zach, Mellana, and Falco hosted Winner’s Semifinals through Loser’s Top 8 on day 1, and Loser’s Quarter-and-Semifinals on day 2\. CzarDB was on the spectator camera across both days. 
+
+What’s the NA League without some silly games? On day 1, two more Riptide interviews yet to be seen were aired, with EE and FTWin, and Kbot and Moonlight. EE and Kbot posed questions to each team, and the team had to point to the teammate that most fit the description. Questions such as “Who is the loudest in chat?” and “Who enjoys practice the most?” were asked to the players. 
+
+On day 2, Jordan held a two-part quiz with Falco, Lily, and Chaedr, asking questions harder than any from previous quizzes, and across the entire Splatoon series. This included lore questions not available in-game, such as, “Before squids, what other animal was considered for the series?” which the answer is rabbits\! 
+
+## **Day 1**
+
+Day 1 of the Splatoon 3 North American League covered every set from the first three rounds: Winner’s Quarterfinals, Winner’s Semifinals, and Loser’s Top 8\. A snapshot of Day 1’s events are below:
+
+**Winner’s Quarterfinals:** 
+
+1. Milky Way vs. healthy diet food groups (3-0)  
+2. Moonlight vs. BEt (3-2)  
+3. FTWin vs. Duck Motif (3-0)  
+4. fofofo vs. Gourmet Race (3-1)
+
+<img width="1200" height="675" alt="0 04percent" src="https://github.com/user-attachments/assets/6b45f9a6-3852-40f2-a558-313be84ffe90" />
+
+*BEt winning against Moonlight in Turf War by 0.04%, the narrowest win margin in the Splatoon 3 North American League, beating the previous record of 1.2%.*
+
+
+**Winner’s Semifinals:** 
+
+1. Milky Way vs. Moonlight (3-1)  
+2. FTWin vs. fofofo (1-3)
+
+**Loser’s Top 8:** 
+
+1. BEt vs. healthy diet food groups (3-0)  
+2. Gourmet Race vs. Duck Motif (0-3)
+
+## **Day 2**
+
+Day 2 streamed each set from Loser’s Quarterfinals, Loser’s Semifinals, Winner’s Finals, Loser’s Finals, and finally, Grand Finals. 
+
+The first set of Loser’s Quarterfinals was FTWin vs. BEt. No one expected to see FTWin in the Loser’s Bracket so early in the tournament, having been sent there by fofofo. FTWin, however, put on a strong showing, shutting BEt out 3-0 and securing themselves a spot in the final four. 
+
+The second set was Moonlight vs. Duck Motif. Moonlight came out on top, 3-1, taking the other spot among the final four teams. The last teams in the tournament–Milky Way, FTWin, fofofo, and Moonlight–were all seeds \#1 \- \#4. 
+
+<img width="1200" height="675" alt="bracketsofar" src="https://github.com/user-attachments/assets/ab6a925a-a0e6-4930-8444-2b30444c8096" />
+
+In the next set, Loser’s Semifinals between FTWin and Moonlight, the Splattercolor Screen was used, so if you plan to rewatch the event and are sensitive to its effects, please take caution as those effects do show up on stream. 
+
+## **Loser’s Semifinals: FTWin vs. Moonlight (1-3)**
+
+Now down to the final four teams of the NA League, for a clash of goliaths. No one anticipated seeing FTWin in the Loser’s Bracket, certainly not as early as the Loser’s Quarterfinals. Moonlight, having a record of never winning against FTWin in the NA League, had one last chance to add a new record to their name in this Playoffs. 
+
+Game one was a classic Splat Zones at Hagglefish Market match. \[K\]yo\! was back with FTWin, replacing Shak after being absent for the first day of Playoffs. FTWin took the zone before Moonlight got too far with it, and they racked up points fast. Right on the dot as the clock reached 2:00, FTWin knocked them out after their Booyah Bomb couldn’t neutralize the zone in time. 
+
+Turf War at Urchin Underpass has been a popular pick throughout the League, and loves to see a weapon shakeup. Both teams brought out the Clawz .96 Gal and REEF-LUX 450 MIL-K, and a Splatana Wiper variant. 
+
+FTWin was in Danger\! before the first minute had passed, and Moonlight set up camp in their base, locking FTWin out from the rest of the map for about 50 seconds. FTWin pushed back, but Moonlight resisted–in the final 10 seconds, FTWin was down three players, letting Moonlight tie the set 1-1 after winning 55.6% to 39.7%. 
+
+Every game of Rainmaker at MakoMart has been full of quick action and curveballs, and this one stands up to the rest. Immediately FTWin made a break for their checkpoint, only to be stopped just shy of the dunk by their opponent. 
+
+After one minute passed, Moonlight, powered by an Ultra Stamp and Ink Vac, broke into FTWin’s spawn and took the lead. They kept the push rolling, moving incrementally closer to the goal. FTWin brought the game into overtime, running the Rainmaker timer to 11 ticks remaining until being taken out, ending in another Moonlight win, 65-43. 
+
+Surprises are still in store: game four went to a new map/mode combo we have yet to see at all on stream during the NA League: Clam Blitz at Humpback Pump Track\! Moonlight was running a double Ultra Stamp composition. And \[K\]yo\! even brought out the Tri-Slosher ASH-N, in a rare weapon swap from FTWin’s captain\! 
+
+This game of Clam Blitz took off without much waiting–FTWin was the first to score, to 62, while Hexen’s Crab Tank kept Moonlight back. Just 40 seconds later, Moonlight scored and took the lead to 33\. In an extended push that saw several players trading splats with one another, FTWin brought the set a new lead to surpass, 19 points. 
+
+<img width="1200" height="675" alt="Basilclam" src="https://github.com/user-attachments/assets/375a80fa-33fe-48c2-846c-572c7ae7824f" />
+
+*Basil, the last player standing on Moonlight, jumps in and throws the last clam to take the lead from FTWin in the last 30 seconds of game four.*
+
+The seconds were ticking down in the final minute. Omega snuck into FTWin’s base, calling for jump-ins. Jumps opened the basket, and Moonlight took the lead by just one clam\! In overtime, Basil–on the Snipewriter 5H–took down every player on FTWin, one by one, securing the 83-81 win, and leading Moonlight to a set upset over FTWin, 3-1\!
+
+...
+
+Continue reading on Splatoon Stronghold's website: [https://www.splatoonstronghold.com/news/the-splatoon-3-north-american-league-playoffs](https://www.splatoonstronghold.com/news/the-splatoon-3-north-american-league-playoffs)
+
+We've recently reworked our article formatting, so we'd appreciate if you could check it out and let us know what you think of the new look\!
+
+
+Original Posting Date: December 16, 2025 
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add article from Splatoon Stronghold, originally posted at https://www.splatoonstronghold.com/news/the-splatoon-3-north-american-league-playoffs