### PR TITLE
Increase precision of `GetTournamentTeamsResponse.seedingPower`

### DIFF
--- a/app/features/api-public/routes/tournament.$id.teams.ts
+++ b/app/features/api-public/routes/tournament.$id.teams.ts
@@ -3,7 +3,7 @@ import { jsonArrayFrom, jsonObjectFrom } from "kysely/helpers/sqlite";
 import { cors } from "remix-utils/cors";
 import { z } from "zod/v4";
 import { db } from "~/db/sql";
-import { ordinalToSp } from "~/features/mmr/mmr-utils";
+import { ordinalToRawSp } from "~/features/mmr/mmr-utils";
 import * as TournamentRepository from "~/features/tournament/TournamentRepository.server";
 import { i18next } from "~/modules/i18n/i18next.server";
 import { nullifyingAvg } from "~/utils/arrays";
@@ -178,5 +178,5 @@ function toSeedingPowerSP(ordinals: (number | null)[]) {
 
 	if (typeof avg !== "number") return null;
 
-	return ordinalToSp(avg);
+	return ordinalToRawSp(avg);
 }

--- a/app/features/mmr/mmr-utils.ts
+++ b/app/features/mmr/mmr-utils.ts
@@ -6,8 +6,12 @@ import { TIERS } from "./mmr-constants";
 
 const TAU = 0.3;
 
+export function ordinalToRawSp(ordinal: number) {
+	return ordinal * 15 + 1000;
+}
+
 export function ordinalToSp(ordinal: number) {
-	return toTwoDecimals(ordinal * 15 + 1000);
+	return toTwoDecimals(ordinalToRawSp(ordinal));
 }
 
 export function ordinalToRoundedSp(ordinal: number) {


### PR DESCRIPTION
This removes the arbitrary precision limit of 2 decimal places for API use. This data doesn't really need to be truncated here as it's provided for machine consumption, not human display.