### PR TITLE
Upgrade better-sqlite3 to v12

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -11,6 +11,7 @@
 		"migrations/**/*.js",
 		"scripts/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
 		"public/sw-2.js",
-		"ley.config.cjs"
+		"ley.config.cjs",
+		"ley-driver.cjs"
 	]
 }

--- a/ley-driver.cjs
+++ b/ley-driver.cjs
@@ -1,0 +1,38 @@
+const { load, MigrationError } = require("ley/lib/util");
+const TEXT = require("ley/lib/text");
+
+exports.connect = (opts = {}) => {
+	const { database, ...rest } = opts;
+	const Database = require("better-sqlite3");
+	return new Database(database, rest);
+};
+
+exports.setup = async (client) => {
+	client.prepare(TEXT.table.replace("serial", "integer")).run();
+	return client.prepare("select name from migrations order by id asc").all();
+};
+
+exports.loop = async (client, files, method) => {
+	const INSERT = client.prepare(
+		"insert into migrations (name,created_at) values (?,current_timestamp)",
+	);
+	const DELETE = client.prepare("delete from migrations where name = ?");
+
+	for (const obj of files) {
+		const file = await load(obj.abs);
+		if (typeof file[method] === "function") {
+			await Promise.resolve(file[method](client)).catch((err) => {
+				throw new MigrationError(err, obj);
+			});
+		}
+		if (method === "up") {
+			INSERT.run(obj.name);
+		} else if (method === "down") {
+			DELETE.run(obj.name);
+		}
+	}
+};
+
+exports.end = async (client) => {
+	await client.close();
+};

--- a/ley.config.cjs
+++ b/ley.config.cjs
@@ -1,3 +1,7 @@
+const path = require("node:path");
 require("dotenv").config();
 
-module.exports = { database: process.env.DB_PATH };
+module.exports = {
+	database: process.env.DB_PATH,
+	driver: path.join(__dirname, "ley-driver.cjs"),
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"@tldraw/tldraw": "^3.12.1",
 				"@zumer/snapdom": "^2.0.1",
 				"aws-sdk": "^2.1693.0",
-				"better-sqlite3": "11.9.1",
+				"better-sqlite3": "^12.5.0",
 				"clsx": "^2.1.1",
 				"compressorjs": "^1.2.1",
 				"date-fns": "^4.1.0",
@@ -8554,14 +8554,17 @@
 			"license": "MIT"
 		},
 		"node_modules/better-sqlite3": {
-			"version": "11.9.1",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.9.1.tgz",
-			"integrity": "sha512-Ba0KR+Fzxh2jDRhdg6TSH0SJGzb8C0aBY4hR8w8madIdIzzC6Y1+kx5qR6eS1Z+Gy20h6ZU28aeyg0z1VIrShQ==",
+			"version": "12.5.0",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.5.0.tgz",
+			"integrity": "sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"bindings": "^1.5.0",
 				"prebuild-install": "^7.1.1"
+			},
+			"engines": {
+				"node": "20.x || 22.x || 23.x || 24.x || 25.x"
 			}
 		},
 		"node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@tldraw/tldraw": "^3.12.1",
 		"@zumer/snapdom": "^2.0.1",
 		"aws-sdk": "^2.1693.0",
-		"better-sqlite3": "11.9.1",
+		"better-sqlite3": "^12.5.0",
 		"clsx": "^2.1.1",
 		"compressorjs": "^1.2.1",
 		"date-fns": "^4.1.0",


### PR DESCRIPTION
## Summary
- Upgrades better-sqlite3 from v11.9.1 to v12.5.0
- Adds custom ley migration driver to fix compatibility issue where better-sqlite3 v12 no longer allows async functions inside transactions

## Test plan
- [x] Run `rm db.sqlite3 && npx ley up` to verify migrations work
- [x] Run `npm run typecheck` 
- [x] Run `npm run test:unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)