### PR TITLE
Fix weapons clearing when selecting 8th weapon in CAST VOD upload

### DIFF
--- a/app/features/vods/routes/vods.new.tsx
+++ b/app/features/vods/routes/vods.new.tsx
@@ -494,7 +494,7 @@ function WeaponsField({
 											const adjustedI = i + teamSize;
 											return (
 												<WeaponSelect
-													key={i}
+													key={adjustedI}
 													isRequired
 													testId={`player-${adjustedI}-weapon`}
 													value={value[adjustedI] ?? null}


### PR DESCRIPTION
The Team 2 weapon selectors were using `key={i}` (giving keys 0,1,2,3) which duplicated Team 1's keys. This caused React's reconciliation to incorrectly reuse component instances when state updated, leading to weapons randomly clearing. Changed to `key={adjustedI}` for unique keys.