### PR TITLE
Fix sub post weapons reverting to user defaults when editing

### DIFF
--- a/app/features/tournament-subs/routes/to.$id.subs.new.tsx
+++ b/app/features/tournament-subs/routes/to.$id.subs.new.tsx
@@ -31,10 +31,12 @@ export default function NewTournamentSubPage() {
 	const data = useLoaderData<typeof loader>();
 
 	const [bestWeapons, setBestWeapons] = React.useState<MainWeaponId[]>(
-		data.sub?.bestWeapons ?? data.userDefaults?.bestWeapons ?? [],
+		data.sub ? data.sub.bestWeapons : (data.userDefaults?.bestWeapons ?? []),
 	);
 	const [okWeapons, setOkWeapons] = React.useState<MainWeaponId[]>(
-		data.sub?.okWeapons ?? data.userDefaults?.okWeapons ?? [],
+		data.sub
+			? (data.sub.okWeapons ?? [])
+			: (data.userDefaults?.okWeapons ?? []),
 	);
 
 	return (


### PR DESCRIPTION
When editing an existing sub post, if the user had removed weapons from "ok with playing", those empty values (stored as null) would fall through the nullish coalescing operator and reload from user profile defaults.

The fix prioritizes existing sub post data over user defaults by checking if a sub post exists first, only falling back to defaults when creating a new sub post.