### PR TITLE
Optimize tournament loader performance

### DIFF
--- a/app/features/tournament/loaders/to.$id.server.ts
+++ b/app/features/tournament/loaders/to.$id.server.ts
@@ -3,12 +3,21 @@ import { getUser } from "~/features/auth/core/user.server";
 import * as TournamentRepository from "~/features/tournament/TournamentRepository.server";
 import { tournamentDataCached } from "~/features/tournament-bracket/core/Tournament.server";
 import { databaseTimestampToDate } from "~/utils/dates";
-import type { SerializeFrom } from "~/utils/remix";
 import { parseParams } from "~/utils/remix.server";
 import { idObject } from "~/utils/zod";
 import { streamsByTournamentId } from "../core/streams.server";
 
-export type TournamentLoaderData = SerializeFrom<typeof loader>;
+export type TournamentLoaderData = {
+	tournament: Awaited<ReturnType<typeof tournamentDataCached>>;
+	streamingParticipants: number[];
+	streamsCount: number;
+	friendCodes:
+		| Awaited<ReturnType<typeof TournamentRepository.friendCodesByTournamentId>>
+		| undefined;
+	preparedMaps:
+		| Awaited<ReturnType<typeof TournamentRepository.findPreparedMapsById>>
+		| undefined;
+};
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
 	const user = getUser();
@@ -46,7 +55,8 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 		);
 	const showFriendCodes = tournamentStartedInTheLastMonth && isTournamentAdmin;
 
-	return {
+	// skip expensive rr7 data serialization (hot path loader)
+	return JSON.stringify({
 		tournament,
 		streamingParticipants: streams.flatMap((s) => (s.userId ? [s.userId] : [])),
 		streamsCount: streams.length,
@@ -57,5 +67,5 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 			isTournamentOrganizer && !tournament.ctx.isFinalized
 				? await TournamentRepository.findPreparedMapsById(tournamentId)
 				: undefined,
-	};
+	});
 };

--- a/app/features/tournament/routes/to.$id.tsx
+++ b/app/features/tournament/routes/to.$id.tsx
@@ -23,7 +23,7 @@ import {
 	tournamentPage,
 	tournamentRegisterPage,
 } from "~/utils/urls";
-import { metaTags, type SerializeFrom } from "../../../utils/remix";
+import { metaTags } from "../../../utils/remix";
 
 import { loader, type TournamentLoaderData } from "../loaders/to.$id.server";
 export { loader };
@@ -43,9 +43,11 @@ export const shouldRevalidate: ShouldRevalidateFunction = (args) => {
 };
 
 export const meta: MetaFunction = (args) => {
-	const data = args.data as SerializeFrom<typeof loader>;
+	const rawData = args.data as string | undefined;
 
-	if (!data) return [];
+	if (!rawData) return [];
+
+	const data = JSON.parse(rawData) as TournamentLoaderData;
 
 	return metaTags({
 		title: data.tournament.ctx.name,
@@ -64,9 +66,11 @@ export const meta: MetaFunction = (args) => {
 export const handle: SendouRouteHandle = {
 	i18n: ["tournament", "calendar"],
 	breadcrumb: ({ match }) => {
-		const data = match.data as TournamentLoaderData | undefined;
+		const rawData = match.data as string | undefined;
 
-		if (!data) return [];
+		if (!rawData) return [];
+
+		const data = JSON.parse(rawData) as TournamentLoaderData;
 
 		return [
 			data.tournament.ctx.organization?.avatarUrl
@@ -112,7 +116,8 @@ export default function TournamentLayoutShell() {
 export function TournamentLayout() {
 	const { t } = useTranslation(["tournament"]);
 	const user = useUser();
-	const data = useLoaderData<typeof loader>();
+	const rawData = useLoaderData<typeof loader>();
+	const data = JSON.parse(rawData) as TournamentLoaderData;
 	const tournament = React.useMemo(
 		() => new Tournament(data.tournament),
 		[data],
@@ -246,8 +251,8 @@ type TournamentContext = {
 	streamingParticipants: number[];
 	setBracketExpanded: (expanded: boolean) => void;
 	friendCode?: string;
-	friendCodes?: SerializeFrom<typeof loader>["friendCodes"];
-	preparedMaps: SerializeFrom<typeof loader>["preparedMaps"];
+	friendCodes?: TournamentLoaderData["friendCodes"];
+	preparedMaps: TournamentLoaderData["preparedMaps"];
 };
 
 export function useTournament() {


### PR DESCRIPTION
## Summary
- Skip React Router's data serialization by returning pre-stringified JSON from the loader
- Define explicit `TournamentLoaderData` type and parse JSON in the route file

## Benchmark (Low Ink January 2026)
| Metric | Before | After |
|--------|--------|-------|
| Avg Latency | 63 ms | 33 ms |
| Req/Sec | 157 | 298 |