### PR TITLE
Fix incorrect score decrement when reopening play-all matches

### DIFF
--- a/app/features/tournament-bracket/actions/to.$id.matches.$mid.server.ts
+++ b/app/features/tournament-bracket/actions/to.$id.matches.$mid.server.ts
@@ -493,7 +493,7 @@ export const action: ActionFunction = async ({ params, request }) => {
 				invariant(scoreOne !== scoreTwo, "Scores are equal");
 				invariant(lastResult, "Last result is missing");
 
-				if (scoreOne > scoreTwo) {
+				if (lastResult.winnerTeamId === match.opponentOne?.id) {
 					scores[0]--;
 				} else {
 					scores[1]--;


### PR DESCRIPTION
In REOPEN_MATCH, the code incorrectly used overall score comparison
to determine which team won the last game. In play-all formats, this
causes bugs when the team with lower overall score won the last game.

Now uses lastResult.winnerTeamId (like UNDO_REPORT_SCORE does) to
correctly determine which score to decrement when reopening a match.