### PR TITLE
Fix checkbox/radio label alignment in form fields

### DIFF
--- a/app/form/fields/FormFieldWrapper.module.css
+++ b/app/form/fields/FormFieldWrapper.module.css
@@ -4,7 +4,7 @@
 	--input-width: 100%;
 }
 
-.root input,
+.root input:not([type="checkbox"]):not([type="radio"]),
 .root textarea,
 .root select,
 .root .react-aria-Group,


### PR DESCRIPTION
Exclude checkbox and radio inputs from the width: 100% rule in
FormFieldWrapper. This was causing labels to appear centered
instead of left-aligned next to the checkboxes in dialogs like
the calendar filter.