### PR TITLE
Add tiers filter to calendar page

### DIFF
--- a/app/features/calendar/calendar-schemas.ts
+++ b/app/features/calendar/calendar-schemas.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { type CalendarEventTag, TOURNAMENT_STAGE_TYPES } from "~/db/tables";
-import { tierNumberToName } from "~/features/tournament/core/tiering";
+import {
+	TIER_NUMBERS,
+	tierNumberToName,
+} from "~/features/tournament/core/tiering";
 import { TOURNAMENT } from "~/features/tournament/tournament-constants";
 import * as Progression from "~/features/tournament-bracket/core/Progression";
 import * as Swiss from "~/features/tournament-bracket/core/Swiss";
@@ -44,7 +47,6 @@ const modeArr = z
 	.min(1)
 	.max(modesShortWithSpecial.length);
 
-const TIER_NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
 const tierItems = TIER_NUMBERS.map((tier) => ({
 	label: () => tierNumberToName(tier),
 	value: String(tier),

--- a/app/features/calendar/components/FiltersDialog.tsx
+++ b/app/features/calendar/components/FiltersDialog.tsx
@@ -82,6 +82,7 @@ function FiltersForm({
 					<FormField name="isSendou" />
 					<FormField name="isRanked" />
 					<FormField name="minTeamCount" />
+					<FormField name="tiers" />
 					<FormField name="orgsIncluded" />
 					<FormField name="orgsExcluded" />
 					<FormField name="authorIdsExcluded" />

--- a/app/features/calendar/core/CalendarEvent.ts
+++ b/app/features/calendar/core/CalendarEvent.ts
@@ -23,6 +23,7 @@ const FILTERS_KEYS = [
 	"modesExact",
 	"minTeamCount",
 	"preferredVersus",
+	"tiers",
 ] as const;
 
 assertType<(typeof FILTERS_KEYS)[number], keyof CalendarFilters>();
@@ -46,6 +47,7 @@ export function defaultFilters(): CalendarFilters {
 		orgsExcluded: [],
 		authorIdsExcluded: [],
 		minTeamCount: 0,
+		tiers: [null, null],
 	};
 }
 
@@ -291,6 +293,26 @@ function matchesFilter(
 			}
 
 			return !authorIds.some((id) => event.authorId === id);
+		}
+		case "tiers": {
+			const [maxTier, minTier] = filters[key];
+			if (maxTier === null && minTier === null) {
+				return true;
+			}
+
+			const eventTier = event.tier ?? event.tentativeTier;
+			if (eventTier === null) {
+				return false;
+			}
+
+			if (maxTier !== null && eventTier < maxTier) {
+				return false;
+			}
+			if (minTier !== null && eventTier > minTier) {
+				return false;
+			}
+
+			return true;
 		}
 	}
 }

--- a/app/features/tournament/core/tiering.ts
+++ b/app/features/tournament/core/tiering.ts
@@ -24,7 +24,21 @@ const SIZE_BONUS = {
 	MAX_BONUS_PER_10_TEAMS: 1.5,
 } as const;
 
-export const TIER_TO_NUMBER = {
+export const TIER_NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
+
+export type TournamentTierNumber = (typeof TIER_NUMBERS)[number];
+export type TournamentTier =
+	| "X"
+	| "S+"
+	| "S"
+	| "A+"
+	| "A"
+	| "B+"
+	| "B"
+	| "C+"
+	| "C";
+
+export const TIER_TO_NUMBER: Record<TournamentTier, TournamentTierNumber> = {
 	X: 1,
 	"S+": 2,
 	S: 3,
@@ -34,9 +48,9 @@ export const TIER_TO_NUMBER = {
 	B: 7,
 	"C+": 8,
 	C: 9,
-} as const;
+};
 
-const NUMBER_TO_TIER = {
+const NUMBER_TO_TIER: Record<TournamentTierNumber, TournamentTier> = {
 	1: "X",
 	2: "S+",
 	3: "S",
@@ -46,10 +60,7 @@ const NUMBER_TO_TIER = {
 	7: "B",
 	8: "C+",
 	9: "C",
-} as const;
-
-export type TournamentTier = keyof typeof TIER_TO_NUMBER;
-export type TournamentTierNumber = (typeof TIER_TO_NUMBER)[TournamentTier];
+};
 
 export function calculateAdjustedScore(
 	rawScore: number,

--- a/locales/en/forms.json
+++ b/locales/en/forms.json
@@ -130,6 +130,8 @@
 	"labels.onlySendouEvents": "Only events hosted on sendou.ink",
 	"labels.onlyRankedEvents": "Only ranked events",
 	"labels.minTeamCount": "Minimum team count",
+	"labels.maxTier": "Max tier",
+	"labels.minTier": "Min tier",
 	"labels.orgsIncluded": "Visible organizations",
 	"labels.orgsExcluded": "Hidden organizations",
 	"labels.authorIdsExcluded": "Authors excluded",


### PR DESCRIPTION
Add a new dualSelect filter for tournament tiers (max/min) on the
calendar events filter. Uses tier field if available, otherwise falls
back to tentativeTier for filtering.