### PR TITLE
Fix tentative tiers disappering

### DIFF
--- a/app/features/tournament-organization/TournamentOrganizationRepository.server.ts
+++ b/app/features/tournament-organization/TournamentOrganizationRepository.server.ts
@@ -416,6 +416,16 @@ export function update({
 			)
 			.execute();
 
+		const existingSeries = await trx
+			.selectFrom("TournamentOrganizationSeries")
+			.select(["name", "tierHistory"])
+			.where("organizationId", "=", id)
+			.execute();
+
+		const tierHistoryByName = new Map(
+			existingSeries.map((s) => [s.name.toLowerCase(), s.tierHistory]),
+		);
+
 		await trx
 			.deleteFrom("TournamentOrganizationSeries")
 			.where("organizationId", "=", id)
@@ -431,6 +441,9 @@ export function update({
 						description: s.description,
 						substringMatches: JSON.stringify([s.name.toLowerCase()]),
 						showLeaderboard: Number(s.showLeaderboard),
+						tierHistory: tierHistoryByName.get(s.name.toLowerCase())
+							? JSON.stringify(tierHistoryByName.get(s.name.toLowerCase()))
+							: null,
 					})),
 				)
 				.execute();

--- a/app/features/tournament-organization/actions/org.$slug.edit.server.ts
+++ b/app/features/tournament-organization/actions/org.$slug.edit.server.ts
@@ -2,6 +2,7 @@ import { type ActionFunctionArgs, redirect } from "react-router";
 import { requireUser } from "~/features/auth/core/user.server";
 import * as ShowcaseTournaments from "~/features/front-page/core/ShowcaseTournaments.server";
 import { clearTournamentDataCache } from "~/features/tournament-bracket/core/Tournament.server";
+import { refreshTentativeTiersCache } from "~/features/tournament-organization/core/tentativeTiers.server";
 import { parseFormData } from "~/form/parse.server";
 import { i18next } from "~/modules/i18n/i18next.server";
 import { requirePermission } from "~/modules/permissions/guards.server";
@@ -63,6 +64,9 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
 	)) {
 		clearTournamentDataCache(tournament.id);
 	}
+
+	// 3) refresh tentative tiers cache (in case series were added/removed/renamed)
+	await refreshTentativeTiersCache();
 
 	return redirect(
 		tournamentOrganizationPage({ organizationSlug: newOrganization.slug }),


### PR DESCRIPTION
"Hey, I was just looking at the calendar and I noticed upcoming editions of Teacup and Milkcup (https://sendou.ink/to/3184/register and https://sendou.ink/to/3193/register) don't have a ranking. Is there any reason why this might be? The previous editions of the tournaments have them."