### PR TITLE
Change Sunken Scrolls URL, update title/description

### DIFF
--- a/app/features/links/links.json
+++ b/app/features/links/links.json
@@ -95,9 +95,9 @@
 		"description": "a guide to improving at Splatoon, beyond raw mechanical ability"
 	},
 	{
-		"title": "Sunken scrolls",
-		"url": "https://scrolls.tessaract.gay/",
-		"description": "an archive for Splatoon guides that would otherwise be lost to time"
+		"title": "Sunken Scrolls",
+		"url": "https://sunkenscrolls.ink",
+		"description": "an archive for Splatoon resources that would otherwise be lost to time"
 	},
 	{
 		"title": "Calculating weapon range sheet",


### PR DESCRIPTION
Sunken Scrolls now has a dedicated domain, so it'd make more sense to link to that. Also changed the description of the site slightly and fixed a capitalization mistake.
