### PR TITLE
fix: add no-refererer to img rendered by markdown

### DIFF
--- a/app/components/Markdown.tsx
+++ b/app/components/Markdown.tsx
@@ -30,7 +30,7 @@ export function Markdown({ children }: { children: string }) {
 							children?: React.ReactNode;
 						}) => (
 							// biome-ignore lint/a11y/useAltText: parsed markdown, so we can't guarantee alt text is present
-							<img {...props} />
+							<img {...props} referrerPolicy="no-referrer" />
 						),
 					},
 				},


### PR DESCRIPTION
## Summary

This PR adds `"referrerPolicy="no-referrer"` to img rendered by markdown. This is a preventive measure to mitigate tracking.

As discussed in supporter channel, it could be possible for a user to add a tracking pixel/image to their profile (intentionally or not) which would allow someone to track IP. This fix does not prevent IP harvesting, but mitigate some issues around it.

### Security concern

This address the following issues/attack vector:

- Mapping IPs to specific users via crafted URLs (e.g. `https://sendou.ink/u/user?id=some-id`)
- Leaking any sensitive query parameters to the external server
- Tracking which specific pages/profiles a visitor is viewing

## Routes changed

- new supporter user profile
- tournament pages 
- article pages 

## Notes

This change is a precaution and for good security hygiene. The risk is low.