### PR TITLE
Stronghold Article "March + April 2026 LANs"

### DIFF
--- a/content/articles/march-april-2026-LANs.md
+++ b/content/articles/march-april-2026-LANs.md
@@ -1,0 +1,79 @@
+---
+title: "March + April 2026 LANs"
+date: 2026-02-26
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+## *Two months of LANs so across the board that even Splatoon for the Wii U is making a comeback*
+
+<img width="1200" height="630" alt="Stronghold_LANs_header_MarchApril" src="https://github.com/user-attachments/assets/361912ed-4676-4686-b57b-42e3a506babe" />
+
+----------
+This article has been truncated. The full article can be found on [Splatoon Stronghold's website.](https://www.splatoonstronghold.com/news/march-april-2026-lans)
+----------
+
+With North America’s LAN Championship Showdown a little more than two months away, the stakes are getting higher and higher. To top it off, a handful of new LANs and yearly gatherings are taking place, making it a great season to travel out\!
+
+## **March 2026**
+
+### **Midwest Battleground 2026 \- March 6–8 (Illinois, United States)**
+- Brand new!
+
+### **VanCoral Mini 2 \- March 7 (Vancouver, Canada)**
+### **GatorLAN Spring 2026 \- March 7–8 (Florida, United States)**
+### **Chi-Shoals \#41 \- March 21 (Illinois, United States)**
+### **LAN of 10,000 Lakes \#1 \- March 21 (Minnesota, United States)**
+- Brand new!
+
+### **Fullwipe 2026 \- March 21–22 (Lyon, France)**
+### **Anarchy NoVA 3 \- March 28 (Virginia, United States)**
+### **HI-SCORE Splatoon LAN \#1 \- March 29 (Hannover, Germany)**
+- Brand new!
+
+## **April 2026**
+
+### **SeaBATTLE\! Royale 2026 \- April 4 (Washington, United States)**
+### **H-Town Splashdown \#7: Blastoff \- April 11 (Texas, United States)**
+### **Big Dapple 10: The Golden Gala \- April 11 (New York, United States)**
+### **CALternative \- April 11 (California, United States)**
+- Splatoon for the Wii U only!
+
+### **New InkLAN \#6 \- April 12 (Massachusetts, United States)**
+### **Sunset Surge: Blossom Blitz \- April 18 (Arizona, United States)**
+### **Don't Flounder at the Function 2 | Spring Break \- April 18 (North Carolina, United States)**
+### **Nittany Nouveau \- April 25–26 (Pennsylvania, United States)**
+
+## **LAN Championship Showdown 2026 \- April 26 (Online)**
+You’ve heard the hype. You’ve seen it brewing over the first four months of 2026\. It’s time to find out who the best LAN local in North America is\! From Torontoroka to Don’t Flounder at the Function 2, twelve LANs have all sent their winners tickets to the LAN Championship Showdown invitational. 
+
+<img width="1000" height="667" alt="LCS2026Map" src="https://github.com/user-attachments/assets/ed37a854-8b0d-4243-ba60-d06d72a9df47" />
+
+[*SplatoonTourney’s*](https://bsky.app/profile/splatoontourney.bsky.social) *LAN Championship Showdown 2026 Qualifiers Map.*
+
+These LANs represent the LCS: 
+
+* Anarchy NoVA (Ashburn, Virginia)  
+* Big Dapple (New York, New York)  
+* Booyah Bay (San Jose, California)  
+* Chi-Shoals (Chicago, Illinois)  
+* Don’t Flounder at the Function (Cary, North Carolina)  
+* GatorLAN (Gainesville, Florida)  
+* H-Town Splashdown (Houston, Texas)  
+* New InkLAN (Waltham, Massachusetts)  
+* SeaBATTLE\! (Seattle, Washington)  
+* SoCallie (Irvine, California)  
+* Sunset Surge (Tempe, Arizona)  
+* Torontoroka (Toronto, Ontario)
+
+Last year, GatorLAN took home the first place gold, with Sunset Surge taking silver and Big Dapple getting bronze. LCS 2025 only had eight teams; 2026 has expanded to twelve teams. The action finds a home on [SplatoonTourney’s Twitch channel](https://www.twitch.tv/SplatoonTourney), on Sunday, April 26th, 2026\. 
+
+With all of the locals continuing in 2026 and new ones preparing to debut, we may see an even bigger LAN Championship Showdown in 2027, representing even more Splatoon communities across the continent\! 
+
+Want an easier way to see which LANs are coming up and nearest to you, without waiting for a bimonthly article? Splatoon Stronghold has an interactive LAN map, with LANs across the globe\! Find it at [https://www.splatoonstronghold.com/lan-map](https://www.splatoonstronghold.com/lan-map)\!
+
+
+Original Posting Date: February 26, 2026
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add article from Splatoon Stronghold, repost of https://www.splatoonstronghold.com/news/march-april-2026-lans
