### PR TITLE
fix: iCal link double slash

### DIFF
--- a/app/features/calendar/core/ICal.server.ts
+++ b/app/features/calendar/core/ICal.server.ts
@@ -31,7 +31,7 @@ function eventsAsICal(events: Array<CalendarEvent>): ics.ReturnObject {
 
 function eventInfoAsICalEvent(event: CalendarEvent): ics.EventAttributes {
 	const startDate = new Date(event.at);
-	const eventLink = `${SENDOU_INK_BASE_URL}/${event.url}`;
+	const eventLink = `${SENDOU_INK_BASE_URL}${event.url}`;
 
 	return {
 		title: event.name,


### PR DESCRIPTION
## Summary

In file rendered by `https://sendou.ink/calendar.ics`, links are rendered with double slash, e.g. : `URL:https://sendou.ink//to/2979` instead of `URL:https://sendou.ink/to/2979`

## Routes changed

`"/calendar.ics", "features/calendar/routes/calendar.ics.tsx"`

## Notes

This is the only instance where a slash is appended to `SENDOU_INK_BASE_URL`
