### PR TITLE
Add uid to .ics feed

### DIFF
--- a/app/features/calendar/core/ICal.server.ts
+++ b/app/features/calendar/core/ICal.server.ts
@@ -34,6 +34,7 @@ function eventInfoAsICalEvent(event: CalendarEvent): ics.EventAttributes {
 	const eventLink = `${SENDOU_INK_BASE_URL}${event.url}`;
 
 	return {
+		uid: `event-${event.id}@sendou.ink`,
 		title: event.name,
 		start: [
 			startDate.getUTCFullYear(),


### PR DESCRIPTION
Closes #2888

By default `nanoid()` is used by the library it seems. Fix seems straightforward but how does this relate to event being updated?