### PR TITLE
Make tournaments with casts always eligible for the sidebar

### DIFF
--- a/app/features/core/streams/streams.server.ts
+++ b/app/features/core/streams/streams.server.ts
@@ -30,8 +30,10 @@ export function getLiveTournamentStreams(): SidebarStream[] {
 	const streams: SidebarStream[] = [];
 
 	for (const tournament of RunningTournaments.all) {
-		if (tournament.isLeagueDivision) continue;
-		if (tournament.minMembersPerTeam < 4) continue;
+		if (tournament.ctx.castStreams.length === 0) {
+			if (tournament.isLeagueDivision) continue;
+			if (tournament.minMembersPerTeam < 4) continue;
+		}
 
 		streams.push({
 			id: `tournament-${tournament.ctx.id}`,


### PR DESCRIPTION
## Summary

Currently league divisions and tournaments <4v4 are excluded from the streams sidebar. This PR makes them always eligible if there are any live casts for the tournament.

## Closes

Closes #2907 
