### PR TITLE
Add `inGameName` to `/api/user/{userId|discordId}` route

### DIFF
--- a/app/features/api-public/routes/user.$identifier.ts
+++ b/app/features/api-public/routes/user.$identifier.ts
@@ -32,6 +32,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 				"User.customUrl",
 				"User.discordId",
 				"User.discordAvatar",
+				"User.inGameName",
 				"User.pronouns",
 				"PlusTier.tier",
 				jsonArrayFrom(
@@ -91,6 +92,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 			: null,
 		url: `https://sendou.ink/u/${user.customUrl ?? user.discordId}`,
 		country: user.country,
+		inGameName: user.inGameName,
 		pronouns: user.pronouns,
 		plusServerTier: user.tier as GetUserResponse["plusServerTier"],
 		socials: {

--- a/app/features/api-public/schema.ts
+++ b/app/features/api-public/schema.ts
@@ -39,6 +39,12 @@ export interface GetUserResponse {
 	/** Teams user is member of. The main team is always first in the array. */
 	teams: Array<GlobalTeamMembership>;
 	/**
+	 * Splatoon 3 splashtag name & ID, if one is set.
+	 *
+	 * @example "Sendou#2955"
+	 */
+	inGameName: string | null;
+	/**
 	 * User's pronouns.
 	 *
 	 * @example { "subject": "he", "object": "him" }


### PR DESCRIPTION
## Summary

Adds an `inGameName` field to the `/api/user/{userId|discordId}` route.

## Routes changed

`/api/user/{userId|discordId}`

## Notes

Currently, only a tournament IGN is available through the API, which is a problem if a developer wants the IGN for purposes other than tournament eligibility. In my case, I'm making a stream overlay with player IGNs.