### PR TITLE
Improve performance when notification dots are visible on-screen

### DIFF
--- a/app/components/NotificationDot.module.css
+++ b/app/components/NotificationDot.module.css
@@ -1,33 +1,42 @@
-.dot {
+.dotWrapper {
 	position: absolute;
 	top: var(--dot-top, -2px);
 	right: var(--dot-right, -2px);
 	width: 8px;
 	height: 8px;
+	pointer-events: none;
+}
+
+.dot {
+	display: block;
+	width: 100%;
+	height: 100%;
+	position: absolute;
 	background-color: var(--color-text-accent);
 	border-radius: 100%;
 	outline: 2px solid var(--color-bg);
-	pointer-events: none;
 }
 
 .pulse {
 	display: block;
-	width: 100%;
-	height: 100%;
-	border-radius: 50%;
+	width: calc(100% + 20px);
+	height: calc(100% + 20px);
+	position: absolute;
+	top: -10px;
+	left: -10px;
+	border-radius: 100%;
 	background-color: var(--color-text-accent);
-	box-shadow: 0 0 0 var(--color-text-accent);
 	animation: pulse 2s infinite;
+	opacity: 0;
 }
 
 @keyframes pulse {
 	from {
-		box-shadow: 0 0 0 0 var(--color-text-accent);
+		transform: scale(0);
+		opacity: 1;
 	}
 	70% {
-		box-shadow: 0 0 0 10px rgba(255, 255, 255, 0);
-	}
-	to {
-		box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+		transform: scale(1);
+		opacity: 0;
 	}
 }

--- a/app/components/NotificationDot.tsx
+++ b/app/components/NotificationDot.tsx
@@ -3,8 +3,9 @@ import styles from "./NotificationDot.module.css";
 
 export function NotificationDot({ className }: { className?: string }) {
 	return (
-		<span className={clsx(styles.dot, className)}>
+		<span className={clsx(styles.dotWrapper, className)}>
 			<span className={styles.pulse} />
+			<span className={styles.dot} />
 		</span>
 	);
 }


### PR DESCRIPTION
## Summary

I was curious why a sendou.ink tab I had open was taking up ~20% CPU while sitting idle and doing seemingly nothing. Some poking around revealed that the issue stemmed from the little dot indicating that the user has unread notifications. Animating the `box-shadow` CSS property triggers a layout and a paint on each animation frame ([according to my sources](https://css-triggers.com/#box-shadow-wrapper)), which is detrimental to performance. This PR replaces the animation with a visually identical one that performs much better (the precise gains vary depending on your browser).

I'd usually refrain from submitting minor performance patches like this, but I figured this one deserved to be fixed since the offending animation plays in an endless loop on practically all pages until notifications are cleared.

The changes were checked on Safari 26.3.1, Chrome 146 and Firefox 150.0b5.