### PR TITLE
feat: Youtube tournament streams

### DIFF
--- a/app/db/tables.ts
+++ b/app/db/tables.ts
@@ -483,7 +483,11 @@ export interface CastedMatchesInfo {
 	/** Array for match ID's that are locked because they are pending to be casted */
 	lockedMatches: number[];
 	/** What matches are streamed currently & where */
-	castedMatches: { twitchAccount: string; matchId: number }[];
+	castedMatches: {
+		twitchAccount?: string;
+		youtubeChannel?: string;
+		matchId: number;
+	}[];
 }
 
 export interface Tournament {
@@ -493,6 +497,7 @@ export interface Tournament {
 	/** Maps prepared ahead of time for rounds. Follows settings.bracketProgression order. Null in the spot if not defined yet for that bracket. */
 	preparedMaps: JSONColumnTypeNullable<(PreparedMaps | null)[]>;
 	castTwitchAccounts: JSONColumnTypeNullable<string[]>;
+	castYoutubeChannels: JSONColumnTypeNullable<string[]>;
 	castedMatchesInfo: JSONColumnTypeNullable<CastedMatchesInfo>;
 	rules: string | null;
 	/** Related "parent tournament", the tournament that contains the original sign-ups (for leagues) */

--- a/app/features/api-public/routes/tournament.$id.casted.ts
+++ b/app/features/api-public/routes/tournament.$id.casted.ts
@@ -27,10 +27,11 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 		current:
 			tournament.castedMatchesInfo?.castedMatches.map((match) => ({
 				matchId: match.matchId,
-				channel: {
-					type: "TWITCH",
-					channelId: match.twitchAccount,
-				},
+				channel: match.twitchAccount
+					? { type: "TWITCH" as const, channelId: match.twitchAccount }
+					: match.youtubeChannel
+						? { type: "YOUTUBE" as const, channelId: match.youtubeChannel }
+						: null,
 			})) ?? [],
 		future:
 			tournament.castedMatchesInfo?.lockedMatches.map((matchId) => ({

--- a/app/features/api-public/schema.ts
+++ b/app/features/api-public/schema.ts
@@ -267,7 +267,7 @@ export interface GetCastedTournamentMatchesResponse {
 	 */
 	current: Array<{
 		matchId: number;
-		channel: TournamentCastChannel;
+		channel: TournamentCastChannel | null;
 	}>;
 	/*
 	 * Matches that are locked to be casted.
@@ -278,13 +278,21 @@ export interface GetCastedTournamentMatchesResponse {
 	}>;
 }
 
-type TournamentCastChannel = {
-	type: "TWITCH";
-	/**
-	 * @example "iplsplatoon"
-	 */
-	channelId: string;
-};
+type TournamentCastChannel =
+	| {
+			type: "TWITCH";
+			/**
+			 * @example "iplsplatoon"
+			 */
+			channelId: string;
+	  }
+	| {
+			type: "YOUTUBE";
+			/**
+			 * @example "UCxxxxxxxxxxxxxxxx"
+			 */
+			channelId: string;
+	  };
 
 /** GET /api/tournament-match/{matchId} */
 

--- a/app/features/tournament-bracket/actions/to.$id.matches.$mid.server.ts
+++ b/app/features/tournament-bracket/actions/to.$id.matches.$mid.server.ts
@@ -542,10 +542,18 @@ export const action: ActionFunction = async ({ params, request }) => {
 				"Not an organizer or streamer",
 			);
 
+			const twitchAccount = data.castChannel?.startsWith("twitch:")
+				? data.castChannel.slice("twitch:".length)
+				: null;
+			const youtubeChannel = data.castChannel?.startsWith("youtube:")
+				? data.castChannel.slice("youtube:".length)
+				: null;
+
 			await TournamentRepository.setMatchAsCasted({
 				matchId: match.id,
 				tournamentId: tournament.ctx.id,
-				twitchAccount: data.twitchAccount,
+				twitchAccount,
+				youtubeChannel,
 			});
 
 			emitTournamentUpdate = true;

--- a/app/features/tournament-bracket/components/Bracket/Match.tsx
+++ b/app/features/tournament-bracket/components/Bracket/Match.tsx
@@ -247,7 +247,7 @@ function MatchStreams({ match }: Pick<MatchProps, "match">) {
 
 	const castingAccount = tournament.ctx.castedMatchesInfo?.castedMatches.find(
 		(cm) => cm.matchId === match.id,
-	)?.twitchAccount;
+	);
 
 	const matchParticipants = [match.opponent1.id, match.opponent2.id].flatMap(
 		(teamId) => tournament.teamById(teamId)?.members.map((m) => m.userId) ?? [],
@@ -256,7 +256,8 @@ function MatchStreams({ match }: Pick<MatchProps, "match">) {
 	const streamsOfThisMatch = tournament.streams.filter(
 		(stream) =>
 			(stream.userId && matchParticipants.includes(stream.userId)) ||
-			stream.twitchUserName === castingAccount,
+			stream.twitchUserName === castingAccount?.twitchAccount ||
+			stream.youtubeChannelId === castingAccount?.youtubeChannel,
 	);
 
 	if (streamsOfThisMatch.length === 0) {
@@ -276,7 +277,11 @@ function MatchStreams({ match }: Pick<MatchProps, "match">) {
 		>
 			{streamsOfThisMatch.map((stream) => (
 				<TournamentStream
-					key={stream.twitchUserName}
+					key={
+						stream.twitchUserName ??
+						stream.youtubeChannelId ??
+						String(stream.userId)
+					}
 					stream={stream}
 					withThumbnail={false}
 				/>

--- a/app/features/tournament-bracket/components/CastInfo.tsx
+++ b/app/features/tournament-bracket/components/CastInfo.tsx
@@ -11,7 +11,7 @@ import { useTournament } from "~/features/tournament/routes/to.$id";
 const lockingInfo =
 	"You can lock the match to indicate that it should not be started before the cast is ready. Match being locked prevents score reporting and hides the map list till the organizer/streamer unlocks it.";
 const setAsCastedInfo =
-	"Select the Twitch account that is currently casting this match. It is then indicated in the bracket view.";
+	"Select the Twitch or YouTube account that is currently casting this match. It is then indicated in the bracket view.";
 
 export function CastInfo({
 	matchIsOngoing,
@@ -29,14 +29,20 @@ export function CastInfo({
 
 	const castedMatchesInfo = tournament.ctx.castedMatchesInfo;
 	const castTwitchAccounts = tournament.ctx.castTwitchAccounts ?? [];
+	const castYoutubeChannels = tournament.ctx.castYoutubeChannels ?? [];
 	const currentlyCastedOn = castedMatchesInfo?.castedMatches.find(
 		(cm) => cm.matchId === matchId,
-	)?.twitchAccount;
+	);
+	const currentTwitchAccount = currentlyCastedOn?.twitchAccount;
+	const currentYoutubeChannel = currentlyCastedOn?.youtubeChannel;
 	const isLocked = castedMatchesInfo?.lockedMatches?.includes(matchId);
 
 	const hasPerms = tournament.isOrganizerOrStreamer(user);
 
-	if (castTwitchAccounts.length === 0 || !hasPerms || matchIsOver) return null;
+	const hasCastAccounts =
+		castTwitchAccounts.length > 0 || castYoutubeChannels.length > 0;
+
+	if (!hasCastAccounts || !hasPerms || matchIsOver) return null;
 
 	// match can only be locked when status is Locked or Waiting (team(s) busy with previous match)
 	if (
@@ -72,38 +78,44 @@ export function CastInfo({
 			submitButtonText="Save"
 			_action="SET_AS_CASTED"
 			infoText={setAsCastedInfo}
-		>
-			<select
-				name="twitchAccount"
-				id="twitchAccount"
-				defaultValue={currentlyCastedOn ?? "null"}
-				data-testid="cast-info-select"
-			>
-				<option value="null">Not casted</option>
-				{castTwitchAccounts.map((account) => (
-					<option key={account} value={account}>
-						{account}
-					</option>
-				))}
-			</select>
-		</CastInfoWrapper>
+			currentTwitchAccount={currentTwitchAccount}
+			currentYoutubeChannel={currentYoutubeChannel}
+			castTwitchAccounts={castTwitchAccounts}
+			castYoutubeChannels={castYoutubeChannels}
+		/>
 	);
 }
 
 function CastInfoWrapper({
-	children,
 	icon,
 	submitButtonText,
 	_action,
 	infoText,
+	currentTwitchAccount,
+	currentYoutubeChannel,
+	castTwitchAccounts,
+	castYoutubeChannels,
 }: {
-	children?: React.ReactNode;
 	icon?: JSX.Element;
 	submitButtonText?: string;
 	_action?: string;
 	infoText?: string;
+	currentTwitchAccount?: string;
+	currentYoutubeChannel?: string;
+	castTwitchAccounts?: string[];
+	castYoutubeChannels?: string[];
 }) {
 	const fetcher = useFetcher();
+
+	const hasCastSelect =
+		(castTwitchAccounts && castTwitchAccounts.length > 0) ||
+		(castYoutubeChannels && castYoutubeChannels.length > 0);
+
+	const currentValue = currentTwitchAccount
+		? `twitch:${currentTwitchAccount}`
+		: currentYoutubeChannel
+			? `youtube:${currentYoutubeChannel}`
+			: "null";
 
 	return (
 		<div className="stack horizontal sm justify-center items-center">
@@ -116,9 +128,13 @@ function CastInfoWrapper({
 				</div>
 
 				<div className="stack horizontal sm items-center justify-between w-full">
-					{children ? (
+					{hasCastSelect ? (
 						<div className="tournament-bracket__cast-info-container__content">
-							{children}
+							<CastSelect
+								currentValue={currentValue}
+								castTwitchAccounts={castTwitchAccounts ?? []}
+								castYoutubeChannels={castYoutubeChannels ?? []}
+							/>
 						</div>
 					) : null}
 					{submitButtonText && _action ? (
@@ -136,5 +152,36 @@ function CastInfoWrapper({
 			</fetcher.Form>
 			{infoText ? <InfoPopover>{infoText}</InfoPopover> : null}
 		</div>
+	);
+}
+
+function CastSelect({
+	currentValue,
+	castTwitchAccounts,
+	castYoutubeChannels,
+}: {
+	currentValue: string;
+	castTwitchAccounts: string[];
+	castYoutubeChannels: string[];
+}) {
+	return (
+		<select
+			name="castChannel"
+			id="castChannel"
+			defaultValue={currentValue}
+			data-testid="cast-info-select"
+		>
+			<option value="null">Not casted</option>
+			{castTwitchAccounts.map((account) => (
+				<option key={`twitch:${account}`} value={`twitch:${account}`}>
+					Twitch: {account}
+				</option>
+			))}
+			{castYoutubeChannels.map((channelId) => (
+				<option key={`youtube:${channelId}`} value={`youtube:${channelId}`}>
+					YouTube: {channelId}
+				</option>
+			))}
+		</select>
 	);
 }

--- a/app/features/tournament-bracket/core/Tournament.server.ts
+++ b/app/features/tournament-bracket/core/Tournament.server.ts
@@ -2,6 +2,7 @@ import * as TournamentRepository from "~/features/tournament/TournamentRepositor
 import { getTentativeTier } from "~/features/tournament-organization/core/tentativeTiers.server";
 import type { TournamentManagerDataSet } from "~/modules/brackets-manager/types";
 import { isAdmin } from "~/modules/permissions/utils";
+import { getLiveStreamsByChannelIds } from "~/modules/youtube";
 import { notFoundIfFalsy } from "~/utils/remix.server";
 import type { Unwrapped } from "~/utils/types";
 import { getServerTournamentManager } from "./brackets-manager/manager.server";
@@ -16,11 +17,23 @@ const combinedTournamentData = async (tournamentId: number) => {
 	const ctx = await TournamentRepository.findById(tournamentId);
 	if (!ctx) return null;
 
+	const youtubeStreams = await getLiveStreamsByChannelIds(
+		ctx.castYoutubeChannels ?? [],
+	);
+
 	return {
 		data: tournamentManagerData(tournamentId),
-		ctx,
+		ctx: {
+			...ctx,
+			youtubeStreams,
+		},
 	};
 };
+
+type CombinedTournamentData = NonNullable<
+	Awaited<ReturnType<typeof combinedTournamentData>>
+>;
+type CombinedTournamentDataContext = CombinedTournamentData["ctx"];
 
 export type TournamentData = NonNullable<Unwrapped<typeof tournamentData>>;
 export type TournamentDataTeam = TournamentData["ctx"]["teams"][number];
@@ -43,7 +56,8 @@ function dataMapped({
 	user,
 }: {
 	data: TournamentManagerDataSet;
-	ctx: TournamentRepository.FindById;
+	ctx: TournamentRepository.FindById &
+		Partial<Pick<CombinedTournamentDataContext, "youtubeStreams">>;
 	user?: { id: number };
 }) {
 	const tournamentHasStarted = data.stage.length > 0;

--- a/app/features/tournament-bracket/core/Tournament.ts
+++ b/app/features/tournament-bracket/core/Tournament.ts
@@ -1396,6 +1396,7 @@ export class Tournament {
 			.map((member) => ({
 				thumbnailUrl: member.streamThumbnailUrl!,
 				twitchUserName: member.streamTwitch!,
+				youtubeChannelId: null as string | null,
 				viewerCount: member.streamViewerCount!,
 				userId: member.userId,
 			}));
@@ -1403,11 +1404,23 @@ export class Tournament {
 		const castStreams = this.ctx.castStreams.map((stream) => ({
 			thumbnailUrl: stream.thumbnailUrl,
 			twitchUserName: stream.twitch!,
+			youtubeChannelId: null as string | null,
 			viewerCount: stream.viewerCount,
 			userId: null as number | null,
 		}));
 
-		return [...memberStreams, ...castStreams].sort(
+		const youtubeCastStreams = (this.ctx.castYoutubeChannels ?? []).map(
+			(channelId) => ({
+				// TODO: fetch YouTube thumbnail and viewer count via YouTube Data API
+				thumbnailUrl: null as string | null,
+				twitchUserName: null as string | null,
+				youtubeChannelId: channelId,
+				viewerCount: 0,
+				userId: null as number | null,
+			}),
+		);
+
+		return [...memberStreams, ...castStreams, ...youtubeCastStreams].sort(
 			(a, b) => b.viewerCount - a.viewerCount,
 		);
 	}

--- a/app/features/tournament-bracket/core/Tournament.ts
+++ b/app/features/tournament-bracket/core/Tournament.ts
@@ -1405,18 +1405,22 @@ export class Tournament {
 			thumbnailUrl: stream.thumbnailUrl,
 			twitchUserName: stream.twitch!,
 			youtubeChannelId: null as string | null,
+			youtubeVideoId: null as string | null,
+			url: null as string | null,
 			viewerCount: stream.viewerCount,
 			userId: null as number | null,
 		}));
 
-		const youtubeCastStreams = (this.ctx.castYoutubeChannels ?? []).map(
-			(channelId) => ({
-				// TODO: fetch YouTube thumbnail and viewer count via YouTube Data API
-				thumbnailUrl: null as string | null,
+		const youtubeCastStreams = (this.ctx.youtubeStreams ?? []).map(
+			(stream) => ({
+				thumbnailUrl: stream.thumbnailUrl,
 				twitchUserName: null as string | null,
-				youtubeChannelId: channelId,
-				viewerCount: 0,
+				youtubeChannelId: stream.youtubeChannelId,
+				youtubeVideoId: stream.youtubeVideoId,
+				url: stream.url,
+				viewerCount: stream.viewerCount,
 				userId: null as number | null,
+				title: stream.title as string | null,
 			}),
 		);
 

--- a/app/features/tournament-bracket/core/tests/mocks-li.ts
+++ b/app/features/tournament-bracket/core/tests/mocks-li.ts
@@ -6904,6 +6904,7 @@ export const LOW_INK_DECEMBER_2024 = (): TournamentData => ({
 			},
 		},
 		castTwitchAccounts: ["iplsplatoon"],
+		castYoutubeChannels: null,
 		castedMatchesInfo: {
 			castedMatches: [
 				{

--- a/app/features/tournament-bracket/core/tests/mocks-sos.ts
+++ b/app/features/tournament-bracket/core/tests/mocks-sos.ts
@@ -2007,6 +2007,7 @@ export const SWIM_OR_SINK_167 = (
 			minMembersPerTeam: 4,
 		},
 		castTwitchAccounts: ["iplsplatoon"],
+		castYoutubeChannels: null,
 		castedMatchesInfo: {
 			castedMatches: [
 				{

--- a/app/features/tournament-bracket/core/tests/mocks-zones-weekly.ts
+++ b/app/features/tournament-bracket/core/tests/mocks-zones-weekly.ts
@@ -318,6 +318,7 @@ export const ZONES_WEEKLY_38 = (): TournamentData => ({
 			},
 		},
 		castTwitchAccounts: null,
+		castYoutubeChannels: null,
 		castedMatchesInfo: null,
 		seedingSnapshot: null,
 		mapPickingStyle: "TO",

--- a/app/features/tournament-bracket/core/tests/mocks.ts
+++ b/app/features/tournament-bracket/core/tests/mocks.ts
@@ -1444,6 +1444,7 @@ export const PADDLING_POOL_257 = () =>
 			},
 			discordUrl: null,
 			castTwitchAccounts: ["dappleproductions"],
+			castYoutubeChannels: null,
 			castedMatchesInfo: {
 				castedMatches: [
 					{
@@ -8044,6 +8045,7 @@ export const PADDLING_POOL_255 = () =>
 			},
 			discordUrl: null,
 			castTwitchAccounts: ["dappleproductions"],
+			castYoutubeChannels: null,
 			castedMatchesInfo: {
 				castedMatches: [
 					{
@@ -14977,6 +14979,7 @@ export const IN_THE_ZONE_32 = ({
 			},
 			discordUrl: null,
 			castTwitchAccounts: ["dappleproductions", "kyochandxd"],
+			castYoutubeChannels: null,
 			castedMatchesInfo: null,
 			seedingSnapshot: null,
 			mapPickingStyle: "AUTO_SZ",

--- a/app/features/tournament-bracket/core/tests/test-utils.ts
+++ b/app/features/tournament-bracket/core/tests/test-utils.ts
@@ -73,6 +73,7 @@ export const testTournament = ({
 			isFinalized: 0,
 			name: "test",
 			castTwitchAccounts: [],
+			castYoutubeChannels: null,
 			bracketProgressionOverrides: [],
 			subCounts: [],
 			staff: [],

--- a/app/features/tournament-bracket/core/tests/test-utils.ts
+++ b/app/features/tournament-bracket/core/tests/test-utils.ts
@@ -81,6 +81,7 @@ export const testTournament = ({
 			toSetMapPool: [],
 			participatedUsers: [],
 			castStreams: [],
+			youtubeStreams: [],
 			mapPickingStyle: "AUTO_SZ",
 			settings: {
 				bracketProgression: [

--- a/app/features/tournament-bracket/tournament-bracket-schemas.server.ts
+++ b/app/features/tournament-bracket/tournament-bracket-schemas.server.ts
@@ -84,9 +84,9 @@ export const matchSchema = z.union([
 	}),
 	z.object({
 		_action: _action("SET_AS_CASTED"),
-		twitchAccount: z.preprocess(
+		castChannel: z.preprocess(
 			nullLiteraltoNull,
-			z.string().min(1).max(100).nullable(),
+			z.string().min(1).max(110).nullable(),
 		),
 	}),
 	z.object({

--- a/app/features/tournament/TournamentRepository.server.ts
+++ b/app/features/tournament/TournamentRepository.server.ts
@@ -48,6 +48,7 @@ export async function findById(id: number) {
 			"CalendarEvent.tags",
 			"Tournament.settings",
 			"Tournament.castTwitchAccounts",
+			"Tournament.castYoutubeChannels",
 			"Tournament.castedMatchesInfo",
 			"Tournament.mapPickingStyle",
 			"Tournament.rules",
@@ -918,6 +919,22 @@ export function updateCastTwitchAccounts({
 		.execute();
 }
 
+export function updateCastYoutubeChannels({
+	tournamentId,
+	castYoutubeChannels,
+}: {
+	tournamentId: number;
+	castYoutubeChannels: string[];
+}) {
+	return db
+		.updateTable("Tournament")
+		.set({
+			castYoutubeChannels: JSON.stringify(castYoutubeChannels),
+		})
+		.where("id", "=", tournamentId)
+		.execute();
+}
+
 const castedMatchesInfoByTournamentId = async (
 	trx: Transaction<DB>,
 	tournamentId: number,
@@ -1005,10 +1022,12 @@ export function setMatchAsCasted({
 	matchId,
 	tournamentId,
 	twitchAccount,
+	youtubeChannel,
 }: {
 	matchId: number;
 	tournamentId: number;
-	twitchAccount: string | null;
+	twitchAccount?: string | null;
+	youtubeChannel?: string | null;
 }) {
 	return db.transaction().execute(async (trx) => {
 		const castedMatchesInfo = await castedMatchesInfoByTournamentId(
@@ -1016,15 +1035,17 @@ export function setMatchAsCasted({
 			tournamentId,
 		);
 
+		const channelValue = twitchAccount ?? youtubeChannel ?? null;
+
 		let newCastedMatchesInfo: CastedMatchesInfo;
-		if (twitchAccount === null) {
+		if (channelValue === null) {
 			newCastedMatchesInfo = {
 				...castedMatchesInfo,
 				castedMatches: castedMatchesInfo.castedMatches.filter(
 					(cm) => cm.matchId !== matchId,
 				),
 			};
-		} else {
+		} else if (twitchAccount) {
 			newCastedMatchesInfo = {
 				...castedMatchesInfo,
 				castedMatches: castedMatchesInfo.castedMatches
@@ -1036,6 +1057,16 @@ export function setMatchAsCasted({
 							cm.matchId !== matchId && cm.twitchAccount !== twitchAccount,
 					)
 					.concat([{ twitchAccount, matchId }]),
+			};
+		} else {
+			newCastedMatchesInfo = {
+				...castedMatchesInfo,
+				castedMatches: castedMatchesInfo.castedMatches
+					.filter(
+						(cm) =>
+							cm.matchId !== matchId && cm.youtubeChannel !== youtubeChannel,
+					)
+					.concat([{ youtubeChannel: youtubeChannel!, matchId }]),
 			};
 		}
 

--- a/app/features/tournament/actions/to.$id.admin.server.ts
+++ b/app/features/tournament/actions/to.$id.admin.server.ts
@@ -369,6 +369,16 @@ export const action: ActionFunction = async ({ request, params }) => {
 			message = "Cast account updated";
 			break;
 		}
+		case "UPDATE_CAST_YOUTUBE_CHANNELS": {
+			validateIsTournamentOrganizer();
+			await TournamentRepository.updateCastYoutubeChannels({
+				tournamentId: tournament.ctx.id,
+				castYoutubeChannels: data.castYoutubeChannels,
+			});
+
+			message = "Cast account updated";
+			break;
+		}
 		case "DROP_TEAM_OUT": {
 			validateIsTournamentOrganizer();
 			const droppingTeam = tournament.teamById(data.teamId);

--- a/app/features/tournament/components/TournamentStream.tsx
+++ b/app/features/tournament/components/TournamentStream.tsx
@@ -18,13 +18,19 @@ export function TournamentStream({
 	);
 	const user = team?.members.find((m) => m.userId === stream.userId);
 
-	const streamUrl = stream.youtubeChannelId
-		? youtubeUrl(stream.youtubeChannelId)
-		: twitchUrl(stream.twitchUserName!);
+	const streamUrl = hasStreamUrl(stream)
+		? stream.url
+		: stream.youtubeChannelId
+			? youtubeUrl(stream.youtubeChannelId)
+			: twitchUrl(stream.twitchUserName!);
 
 	const streamLabel = stream.youtubeChannelId
-		? stream.youtubeChannelId
+		? (("title" in stream && stream.title) || stream.youtubeChannelId)
 		: stream.twitchUserName!;
+
+	const thumbnailUrl = stream.youtubeChannelId
+		? stream.thumbnailUrl
+		: twitchThumbnailUrlToSrc(stream.thumbnailUrl!);
 
 	return (
 		<div
@@ -34,12 +40,7 @@ export function TournamentStream({
 		>
 			{withThumbnail && stream.thumbnailUrl ? (
 				<a href={streamUrl} target="_blank" rel="noreferrer">
-					<img
-						alt=""
-						src={twitchThumbnailUrlToSrc(stream.thumbnailUrl)}
-						width={320}
-						height={180}
-					/>
+					<img alt="" src={thumbnailUrl} width={320} height={180} />
 				</a>
 			) : null}
 			<div className="stack md horizontal justify-between">
@@ -51,7 +52,7 @@ export function TournamentStream({
 				) : (
 					<div className="tournament__stream__user-container">
 						<Avatar size="xxs" url={tournament.ctx.logoUrl} />
-						Cast <span className="text-lighter">{streamLabel}</span>
+						Cast <span className="text-lighter" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: "200px", display: "inline-block", verticalAlign: "bottom" }}>{streamLabel}</span>
 					</div>
 				)}
 				<div className="tournament__stream__viewer-count">
@@ -71,4 +72,10 @@ export function TournamentStream({
 			) : null}
 		</div>
 	);
+}
+
+function hasStreamUrl(
+	stream: Tournament["streams"][number],
+): stream is Tournament["streams"][number] & { url: string } {
+	return "url" in stream && typeof stream.url === "string";
 }

--- a/app/features/tournament/components/TournamentStream.tsx
+++ b/app/features/tournament/components/TournamentStream.tsx
@@ -2,7 +2,7 @@ import { Avatar } from "~/components/Avatar";
 import { UserIcon } from "~/components/icons/User";
 import type { Tournament } from "~/features/tournament-bracket/core/Tournament";
 import { twitchThumbnailUrlToSrc } from "~/modules/twitch/utils";
-import { twitchUrl } from "~/utils/urls";
+import { twitchUrl, youtubeUrl } from "~/utils/urls";
 import { useTournament } from "../routes/to.$id";
 
 export function TournamentStream({
@@ -18,18 +18,22 @@ export function TournamentStream({
 	);
 	const user = team?.members.find((m) => m.userId === stream.userId);
 
+	const streamUrl = stream.youtubeChannelId
+		? youtubeUrl(stream.youtubeChannelId)
+		: twitchUrl(stream.twitchUserName!);
+
+	const streamLabel = stream.youtubeChannelId
+		? stream.youtubeChannelId
+		: stream.twitchUserName!;
+
 	return (
 		<div
 			key={stream.userId}
 			className="stack sm"
 			data-testid="tournament-stream"
 		>
-			{withThumbnail ? (
-				<a
-					href={twitchUrl(stream.twitchUserName)}
-					target="_blank"
-					rel="noreferrer"
-				>
+			{withThumbnail && stream.thumbnailUrl ? (
+				<a href={streamUrl} target="_blank" rel="noreferrer">
 					<img
 						alt=""
 						src={twitchThumbnailUrlToSrc(stream.thumbnailUrl)}
@@ -47,7 +51,7 @@ export function TournamentStream({
 				) : (
 					<div className="tournament__stream__user-container">
 						<Avatar size="xxs" url={tournament.ctx.logoUrl} />
-						Cast <span className="text-lighter">{stream.twitchUserName}</span>
+						Cast <span className="text-lighter">{streamLabel}</span>
 					</div>
 				)}
 				<div className="tournament__stream__viewer-count">
@@ -57,7 +61,7 @@ export function TournamentStream({
 			</div>
 			{!withThumbnail ? (
 				<a
-					href={twitchUrl(stream.twitchUserName)}
+					href={streamUrl}
 					target="_blank"
 					rel="noreferrer"
 					className="text-xxs text-semi-bold text-center"

--- a/app/features/tournament/routes/to.$id.admin.tsx
+++ b/app/features/tournament/routes/to.$id.admin.tsx
@@ -114,6 +114,8 @@ export default function TournamentAdminPage() {
 			) : null}
 			<Divider smallText>Cast Twitch Accounts</Divider>
 			<CastTwitchAccounts />
+			<Divider smallText>Cast YouTube Channels</Divider>
+			<CastYoutubeChannels />
 			<Divider smallText>Participant list download</Divider>
 			<DownloadParticipants />
 			{!tournament.isLeagueSignup ? (
@@ -427,6 +429,39 @@ function CastTwitchAccounts() {
 				automatically based on their profile data. You can also enter multiple
 				accounts, just separate them with a comma e.g.
 				&quot;sendouc,leanny&quot;
+			</FormMessage>
+		</fetcher.Form>
+	);
+}
+
+function CastYoutubeChannels() {
+	const id = React.useId();
+	const fetcher = useFetcher();
+	const tournament = useTournament();
+
+	return (
+		<fetcher.Form method="post" className="stack sm">
+			<div className="stack horizontal sm items-end">
+				<div>
+					<Label htmlFor={id}>YouTube channel IDs</Label>
+					<input
+						id={id}
+						placeholder="UCxxxxxxxxxxxxxxxx"
+						name="castYoutubeChannels"
+						defaultValue={tournament.ctx.castYoutubeChannels?.join(",")}
+					/>
+				</div>
+				<SubmitButton
+					testId="save-cast-youtube-channels-button"
+					state={fetcher.state}
+					_action="UPDATE_CAST_YOUTUBE_CHANNELS"
+				>
+					Save
+				</SubmitButton>
+			</div>
+			<FormMessage type="info">
+				YouTube channel ID where the tournament is casted. You can also enter
+				multiple IDs, just separate them with a comma.
 			</FormMessage>
 		</fetcher.Form>
 	);

--- a/app/features/tournament/routes/to.$id.streams.tsx
+++ b/app/features/tournament/routes/to.$id.streams.tsx
@@ -24,8 +24,19 @@ export default function TournamentStreamsPage() {
 	return (
 		<div className="stack horizontal lg flex-wrap justify-center">
 			{tournament.streams.map((stream) => (
-				<TournamentStream key={stream.twitchUserName} stream={stream} />
+				<TournamentStream
+					key={
+						stream.twitchUserName ??
+						stream.youtubeChannelId ??
+						String(stream.userId)
+					}
+					stream={stream}
+				/>
 			))}
 		</div>
 	);
 }
+
+
+
+

--- a/app/features/tournament/tournament-schemas.server.ts
+++ b/app/features/tournament/tournament-schemas.server.ts
@@ -158,6 +158,19 @@ export const adminActionSchema = z.union([
 		),
 	}),
 	z.object({
+		_action: _action("UPDATE_CAST_YOUTUBE_CHANNELS"),
+		castYoutubeChannels: z.preprocess(
+			(val) =>
+				typeof val === "string"
+					? val
+							.split(",")
+							.map((channel) => channel.trim())
+							.filter(Boolean)
+					: val,
+			z.array(z.string()),
+		),
+	}),
+	z.object({
 		_action: _action("RESET_BRACKET"),
 		stageId: id,
 	}),

--- a/app/modules/youtube/index.ts
+++ b/app/modules/youtube/index.ts
@@ -1,0 +1,1 @@
+export { getLiveStreamsByChannelIds } from "./streams";

--- a/app/modules/youtube/schemas.ts
+++ b/app/modules/youtube/schemas.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import type { Unpacked } from "~/utils/types";
+
+export const youtubeSearchResponseSchema = z.object({
+	items: z.array(
+		z.object({
+			id: z.object({
+				videoId: z.string(),
+			}),
+			snippet: z.object({
+				channelId: z.string(),
+				title: z.string(),
+				thumbnails: z
+					.object({
+						default: z.object({ url: z.string() }).optional(),
+						medium: z.object({ url: z.string() }).optional(),
+						high: z.object({ url: z.string() }).optional(),
+						standard: z.object({ url: z.string() }).optional(),
+						maxres: z.object({ url: z.string() }).optional(),
+					})
+					.optional(),
+			}),
+		}),
+	),
+});
+
+export const youtubeVideosResponseSchema = z.object({
+	items: z.array(
+		z.object({
+			id: z.string(),
+			snippet: z.object({
+				channelId: z.string(),
+				title: z.string(),
+				thumbnails: z
+					.object({
+						default: z.object({ url: z.string() }).optional(),
+						medium: z.object({ url: z.string() }).optional(),
+						high: z.object({ url: z.string() }).optional(),
+						standard: z.object({ url: z.string() }).optional(),
+						maxres: z.object({ url: z.string() }).optional(),
+					})
+					.optional(),
+			}),
+			liveStreamingDetails: z
+				.object({
+					concurrentViewers: z.string().optional(),
+				})
+				.optional(),
+		}),
+	),
+});
+
+export type YouTubeSearchItem = Unpacked<
+	z.infer<typeof youtubeSearchResponseSchema>["items"]
+>;
+export type YouTubeVideoItem = Unpacked<
+	z.infer<typeof youtubeVideosResponseSchema>["items"]
+>;

--- a/app/modules/youtube/streams.ts
+++ b/app/modules/youtube/streams.ts
@@ -1,0 +1,177 @@
+import { cachified } from "@epic-web/cachified";
+import * as R from "remeda";
+import { cache, ttl } from "~/utils/cache.server";
+import { IS_E2E_TEST_RUN } from "~/utils/e2e";
+import { logger } from "~/utils/logger";
+import { assertUnreachable } from "~/utils/types";
+import {
+	type YouTubeSearchItem,
+	type YouTubeVideoItem,
+	youtubeSearchResponseSchema,
+	youtubeVideosResponseSchema,
+} from "./schemas";
+import { getYouTubeEnvVars, hasYouTubeEnvVars, youtubeVideoUrl } from "./utils";
+
+const YOUTUBE_SEARCH_URL = "https://www.googleapis.com/youtube/v3/search";
+const YOUTUBE_VIDEOS_URL = "https://www.googleapis.com/youtube/v3/videos";
+
+export async function getLiveStreamsByChannelIds(channelIds: string[]) {
+	const distinctChannelIds = R.pipe(
+		channelIds,
+		R.unique(),
+		R.sortBy(R.identity()),
+	);
+
+	if (distinctChannelIds.length === 0) return [];
+	if (!hasYouTubeEnvVars()) return [];
+	if (process.env.NODE_ENV === "test" || IS_E2E_TEST_RUN) return [];
+
+	try {
+		return await cachified({
+			key: `youtube-streams:${distinctChannelIds.join(",")}`,
+			cache,
+			ttl: ttl(1000 * 60 * 2),
+			staleWhileRevalidate: ttl(1000 * 60 * 10),
+			async getFreshValue() {
+				return getFreshStreams(distinctChannelIds);
+			},
+		});
+	} catch (error) {
+		logger.error(error);
+		return [];
+	}
+}
+
+async function getFreshStreams(channelIds: string[]) {
+	const liveSearchResults = await Promise.all(
+		channelIds.map(async (channelId) => {
+			const item = await getLiveVideoByChannelId(channelId);
+			return item ? { channelId, item } : null;
+		}),
+	);
+
+	const liveVideos = liveSearchResults.filter(R.isTruthy);
+	if (liveVideos.length === 0) return [];
+
+	const videoDetails = await getVideoDetails(
+		liveVideos.map(({ item }) => item.id.videoId),
+	);
+
+	return liveVideos
+		.map(({ channelId, item }) => {
+			const details = videoDetails.find(
+				(video) => video.id === item.id.videoId,
+			);
+			return mapLiveStream({ channelId, searchItem: item, videoItem: details });
+		})
+		.filter(R.isTruthy)
+		.sort((a, b) => b.viewerCount - a.viewerCount);
+}
+
+function mapLiveStream({
+	channelId,
+	searchItem,
+	videoItem,
+}: {
+	channelId: string;
+	searchItem: YouTubeSearchItem;
+	videoItem: YouTubeVideoItem | undefined;
+}) {
+	const thumbnailUrl = pickThumbnailUrl(videoItem?.snippet.thumbnails);
+	if (!thumbnailUrl) return null;
+
+	return {
+		thumbnailUrl,
+		viewerCount: Number(
+			videoItem?.liveStreamingDetails?.concurrentViewers ?? 0,
+		),
+		youtubeChannelId: channelId,
+		youtubeVideoId: searchItem.id.videoId,
+		title: videoItem?.snippet.title ?? searchItem.snippet.title,
+		url: youtubeVideoUrl(searchItem.id.videoId),
+	};
+}
+
+async function getLiveVideoByChannelId(channelId: string) {
+	const { YOUTUBE_API_KEY } = getYouTubeEnvVars();
+	const url = new URL(YOUTUBE_SEARCH_URL);
+
+	url.searchParams.set("part", "snippet");
+	url.searchParams.set("channelId", channelId);
+	url.searchParams.set("eventType", "live");
+	url.searchParams.set("type", "video");
+	url.searchParams.set("maxResults", "1");
+	url.searchParams.set("key", YOUTUBE_API_KEY);
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Getting YouTube live video failed with status code: ${response.status}`,
+		);
+	}
+
+	const parsed = youtubeSearchResponseSchema.safeParse(await response.json());
+	if (!parsed.success) {
+		throw new Error(parsed.error.message);
+	}
+
+	return parsed.data.items[0] ?? null;
+}
+
+async function getVideoDetails(videoIds: string[]) {
+	if (videoIds.length === 0) return [];
+
+	const { YOUTUBE_API_KEY } = getYouTubeEnvVars();
+	const url = new URL(YOUTUBE_VIDEOS_URL);
+
+	url.searchParams.set("part", "snippet,liveStreamingDetails");
+	url.searchParams.set("id", videoIds.join(","));
+	url.searchParams.set("key", YOUTUBE_API_KEY);
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Getting YouTube video details failed with status code: ${response.status}`,
+		);
+	}
+
+	const parsed = youtubeVideosResponseSchema.safeParse(await response.json());
+	if (!parsed.success) {
+		throw new Error(parsed.error.message);
+	}
+
+	return parsed.data.items;
+}
+
+function pickThumbnailUrl(
+	thumbnails:
+		| YouTubeSearchItem["snippet"]["thumbnails"]
+		| YouTubeVideoItem["snippet"]["thumbnails"]
+		| undefined,
+) {
+	if (!thumbnails) return null;
+
+	for (const size of [
+		"maxres",
+		"standard",
+		"high",
+		"medium",
+		"default",
+	] as const) {
+		switch (size) {
+			case "maxres":
+			case "standard":
+			case "high":
+			case "medium":
+			case "default": {
+				const thumbnail = thumbnails[size];
+				if (thumbnail?.url) return thumbnail.url;
+				break;
+			}
+			default:
+				assertUnreachable(size);
+		}
+	}
+
+	return null;
+}

--- a/app/modules/youtube/utils.ts
+++ b/app/modules/youtube/utils.ts
@@ -1,0 +1,17 @@
+import invariant from "~/utils/invariant";
+
+export const hasYouTubeEnvVars = () => Boolean(process.env.YOUTUBE_API_KEY);
+
+export const getYouTubeEnvVars = () => {
+	const { YOUTUBE_API_KEY } = process.env;
+
+	invariant(
+		YOUTUBE_API_KEY,
+		"Missing YOUTUBE_API_KEY env var, showing no streams",
+	);
+
+	return { YOUTUBE_API_KEY };
+};
+
+export const youtubeVideoUrl = (videoId: string) =>
+	`https://youtube.com/watch?v=${videoId}`;

--- a/migrations/120-cast-youtube-channels.js
+++ b/migrations/120-cast-youtube-channels.js
@@ -1,0 +1,5 @@
+export function up(db) {
+	db.prepare(
+		/* sql */ `alter table "Tournament" add column "castYoutubeChannels" text`,
+	).run();
+}


### PR DESCRIPTION
---                                                                                                                                                                                                                                                          
  Summary                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                               
  - Add support for YouTube channels in tournament casting streams                                                                                                                                                                                             
  - YouTube live streams are fetched via YouTube Data API v3 and displayed alongside Twitch streams on the tournament streams page                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                               
  Routes changed                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                               
  - /to/:id/streams — now displays YouTube cast streams in addition to Twitch streams                                                                                                                                                                          
                                                                                                                                                                                                                                                             
  Notes                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                             
  - Requires YOUTUBE_API_KEY environment variable to be set (YouTube Data API v3 key).     
  - Please test carefully         
  - To get a channel's UC ID: open the channel page → Share → Copy channel ID        
                                   