### PR TITLE
Make <4v4 streams appear on front page, with a penalty

### DIFF
--- a/app/features/core/streams/streams.server.ts
+++ b/app/features/core/streams/streams.server.ts
@@ -21,6 +21,7 @@ export type SidebarStream = {
 	subtitle: string;
 	startsAt: number;
 	tier: TournamentTierNumber | null;
+	membersPerTeam?: number
 	tentativeTier?: number;
 	peakXp?: number;
 	twitchUsername?: string;
@@ -31,7 +32,6 @@ export function getLiveTournamentStreams(): SidebarStream[] {
 
 	for (const tournament of RunningTournaments.all) {
 		if (tournament.isLeagueDivision) continue;
-		if (tournament.minMembersPerTeam < 4) continue;
 
 		streams.push({
 			id: `tournament-${tournament.ctx.id}`,
@@ -41,6 +41,7 @@ export function getLiveTournamentStreams(): SidebarStream[] {
 			subtitle: deriveCurrentRound(tournament),
 			startsAt: dateToDatabaseTimestamp(tournament.ctx.startTime),
 			tier: tournament.ctx.tier,
+			membersPerTeam: tournament.minMembersPerTeam,
 		});
 	}
 

--- a/app/features/sidebar/core/StreamRanking.ts
+++ b/app/features/sidebar/core/StreamRanking.ts
@@ -27,8 +27,9 @@ export function rank(
 
 export function tournamentTierToScore(
 	tier: TournamentTierNumber | null,
+	membersPerTeam?: number,
 ): number {
-	return tier ?? 9;
+	return Math.min(9, (tier ?? 9) + 4 - (membersPerTeam ?? 4));
 }
 
 export function upcomingTournamentTierToScore(tier: number): number {

--- a/app/features/sidebar/core/sidebar.server.ts
+++ b/app/features/sidebar/core/sidebar.server.ts
@@ -152,7 +152,7 @@ async function combinedStreams(): Promise<SidebarStream[]> {
 	for (const stream of tournamentStreams) {
 		ranked.push({
 			stream,
-			score: StreamRanking.tournamentTierToScore(stream.tier),
+			score: StreamRanking.tournamentTierToScore(stream.tier, stream.membersPerTeam),
 		});
 	}
 


### PR DESCRIPTION
## Summary

This makes streams <4v4 appear on the front page again, but they're discounted based on their size. 3v3 is treated as one tier lower, and 1v1 is treated as 3 tiers lower.

## Routes changed

[`app/root.tsx`](https://github.com/sendou-ink/sendou.ink/blob/main/app/root.tsx)

## Notes

https://discord.com/channels/299182152161951744/784073459516964954/1489320064455938159

## Closes

#2907 
