### PR TITLE
Search shortcuts

### DIFF
--- a/app/components/layout/GlobalSearch.module.css
+++ b/app/components/layout/GlobalSearch.module.css
@@ -103,25 +103,22 @@
 	align-items: center;
 	border-bottom: 1px solid var(--color-border);
 
-	&:has(.input:focus-within) {
+	&:focus-within {
 		border-color: var(--color-text-accent);
 	}
 }
 
 .inputPrefix {
-	all: unset;
-	margin: 0;
-	padding: 0;
-	border: none;
 	font-size: var(--font-xs);
 	color: var(--color-text-high);
 	margin-left: var(--s-4);
 	background-color: var(--color-bg-high);
 	border-radius: var(--radius-selector);
-	width: var(--s-4);
 	height: var(--selector-size);
 	padding-inline: var(--s-1);
 	text-align: center;
+	width: var(--s-8);
+	line-height: 1.75;
 }
 
 .input.input {

--- a/app/components/layout/GlobalSearch.module.css
+++ b/app/components/layout/GlobalSearch.module.css
@@ -98,15 +98,41 @@
 	outline: none;
 }
 
+.inputContainer {
+	display: flex;
+	align-items: center;
+	border-bottom: 1px solid var(--color-border);
+
+	&:has(.input:focus-within) {
+		border-color: var(--color-text-accent);
+	}
+}
+
+.inputPrefix {
+	all: unset;
+	margin: 0;
+	padding: 0;
+	border: none;
+	font-size: var(--font-xs);
+	color: var(--color-text-high);
+	margin-left: var(--s-4);
+	background-color: var(--color-bg-high);
+	border-radius: var(--radius-selector);
+	width: var(--s-4);
+	height: var(--selector-size);
+	padding-inline: var(--s-1);
+	text-align: center;
+}
+
 .input.input {
 	padding: var(--s-4);
 	border: none;
-	border-bottom: 1px solid var(--color-border);
 	border-radius: 0;
 	background: transparent;
 	font-size: var(--font-md);
 	color: var(--color-text);
 	height: auto;
+	padding-left: 0;
 
 	& input::placeholder {
 		color: var(--color-text-high);
@@ -114,7 +140,6 @@
 
 	&:focus-within {
 		outline: none;
-		border-color: var(--color-text-accent);
 	}
 }
 

--- a/app/components/layout/GlobalSearch.tsx
+++ b/app/components/layout/GlobalSearch.tsx
@@ -283,7 +283,7 @@ function GlobalSearchContent({
 
 	const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const value = e.target.value;
-		const separatorMatch = value.match(/^([a-zA-Z]+): /);
+		const separatorMatch = value.match(/^([a-zA-Z]+)\. /);
 		if (separatorMatch) {
 			const typedPrefix = separatorMatch[1];
 			const matchedType = SEARCH_TYPES.find(
@@ -318,7 +318,7 @@ function GlobalSearchContent({
 	const handlePrefixChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const value = e.target.value;
 		setEditablePrefix(value);
-		if (!value.endsWith(":") && !value.endsWith(" ")) return;
+		if (!value.endsWith(".") && !value.endsWith(" ")) return;
 
 		const typedPrefix = value.slice(0, -1);
 		const matchedType = SEARCH_TYPES.find(
@@ -374,7 +374,7 @@ function GlobalSearchContent({
 					value={
 						isPrefixEditable
 							? editablePrefix
-							: `${SEARCH_TYPE_TO_PREFIX[searchType]}:`
+							: `${SEARCH_TYPE_TO_PREFIX[searchType]}.`
 					}
 					readOnly={!isPrefixEditable}
 					onChange={handlePrefixChange}

--- a/app/components/layout/GlobalSearch.tsx
+++ b/app/components/layout/GlobalSearch.tsx
@@ -277,7 +277,7 @@ function GlobalSearchContent({
 
 	const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const value = e.target.value;
-		const separatorMatch = value.match(/^([a-zA-Z]+)\. /);
+		const separatorMatch = value.match(/^([a-zA-Z]+)\.(?=[a-zA-Z ]) ?/);
 
 		if (separatorMatch) {
 			const typedPrefix = separatorMatch[1];

--- a/app/components/layout/GlobalSearch.tsx
+++ b/app/components/layout/GlobalSearch.tsx
@@ -198,12 +198,8 @@ function GlobalSearchContent({
 		);
 
 	const inputRef = React.useRef<HTMLInputElement>(null);
-	const prefixInputRef = React.useRef<HTMLInputElement>(null);
 	const listBoxRef = React.useRef<HTMLDivElement>(null);
 	const modifierKeyRef = React.useRef(false);
-
-	const [isPrefixEditable, setIsPrefixEditable] = React.useState(false);
-	const [editablePrefix, setEditablePrefix] = React.useState("");
 
 	const handleClickCapture = (e: React.MouseEvent) => {
 		modifierKeyRef.current = e.metaKey || e.ctrlKey;
@@ -277,8 +273,6 @@ function GlobalSearchContent({
 	const handleSearchTypeChange = (value: string) => {
 		setSearchType(value as SearchType);
 		setSelectedWeapon(null);
-		setIsPrefixEditable(false);
-		setEditablePrefix("");
 	};
 
 	const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -302,43 +296,11 @@ function GlobalSearchContent({
 	};
 
 	const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-		if (e.key === "Backspace" && query === "") {
-			e.preventDefault();
-			setIsPrefixEditable(true);
-			setEditablePrefix("");
-			prefixInputRef.current?.focus();
-			return;
-		}
-
 		const currentResults = searchType === "weapons" ? weaponResults : results;
 		if (e.key === "ArrowDown" && currentResults.length > 0) {
 			e.preventDefault();
 			listBoxRef.current?.focus();
 		}
-	};
-
-	const handlePrefixChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const value = e.target.value;
-		setEditablePrefix(value);
-		const separatorMatch = value.match(/^([a-zA-Z]+)\.? $/);
-		if (!separatorMatch) return;
-
-		const typedPrefix = separatorMatch[1];
-		const matchedType = SEARCH_TYPES.find(
-			(type) => SEARCH_TYPE_TO_PREFIX[type] === typedPrefix,
-		);
-		if (!matchedType) return;
-
-		setSearchType(matchedType);
-		setSelectedWeapon(null);
-		setIsPrefixEditable(false);
-		setEditablePrefix("");
-		inputRef.current?.focus();
-	};
-
-	const handlePrefixBlur = () => {
-		setIsPrefixEditable(false);
-		setEditablePrefix("");
 	};
 
 	const handleDestinationSelect = () => {
@@ -370,19 +332,9 @@ function GlobalSearchContent({
 	return (
 		<div onClickCapture={handleClickCapture}>
 			<div className={styles.inputContainer}>
-				<input
-					ref={prefixInputRef}
-					className={styles.inputPrefix}
-					type="text"
-					value={
-						isPrefixEditable
-							? editablePrefix
-							: `${SEARCH_TYPE_TO_PREFIX[searchType]}.`
-					}
-					readOnly={!isPrefixEditable}
-					onChange={handlePrefixChange}
-					onBlur={handlePrefixBlur}
-				/>
+				<p className={styles.inputPrefix}>
+					{`${SEARCH_TYPE_TO_PREFIX[searchType]}.`}
+				</p>
 				<Input
 					ref={inputRef}
 					className={styles.input}

--- a/app/components/layout/GlobalSearch.tsx
+++ b/app/components/layout/GlobalSearch.tsx
@@ -284,6 +284,7 @@ function GlobalSearchContent({
 	const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const value = e.target.value;
 		const separatorMatch = value.match(/^([a-zA-Z]+)\. /);
+
 		if (separatorMatch) {
 			const typedPrefix = separatorMatch[1];
 			const matchedType = SEARCH_TYPES.find(
@@ -296,6 +297,7 @@ function GlobalSearchContent({
 				return;
 			}
 		}
+
 		setQuery(value);
 	};
 
@@ -318,9 +320,10 @@ function GlobalSearchContent({
 	const handlePrefixChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const value = e.target.value;
 		setEditablePrefix(value);
-		if (!value.endsWith(".") && !value.endsWith(" ")) return;
+		const separatorMatch = value.match(/^([a-zA-Z]+)\.? $/);
+		if (!separatorMatch) return;
 
-		const typedPrefix = value.slice(0, -1);
+		const typedPrefix = separatorMatch[1];
 		const matchedType = SEARCH_TYPES.find(
 			(type) => SEARCH_TYPE_TO_PREFIX[type] === typedPrefix,
 		);

--- a/app/components/layout/GlobalSearch.tsx
+++ b/app/components/layout/GlobalSearch.tsx
@@ -315,6 +315,11 @@ function GlobalSearchContent({
 		inputRef.current?.focus();
 	};
 
+	const handlePrefixBlur = () => {
+		setIsPrefixEditable(false);
+		setEditablePrefix("");
+	};
+
 	const handleDestinationSelect = () => {
 		if (!selectedWeapon) return;
 
@@ -355,6 +360,7 @@ function GlobalSearchContent({
 					}
 					readOnly={!isPrefixEditable}
 					onChange={handlePrefixChange}
+					onBlur={handlePrefixBlur}
 				/>
 				<Input
 					ref={inputRef}

--- a/app/components/layout/GlobalSearch.tsx
+++ b/app/components/layout/GlobalSearch.tsx
@@ -48,6 +48,14 @@ const SEARCH_TYPES = [
 ] as const;
 type SearchType = (typeof SEARCH_TYPES)[number];
 
+const SEARCH_TYPE_TO_PREFIX: Record<SearchType, string> = {
+	weapons: "w",
+	users: "u",
+	teams: "t",
+	organizations: "o",
+	tournaments: "to",
+};
+
 const STORAGE_KEY = "global-search-search-type";
 
 function searchTypeIconPath(type: SearchType): string {
@@ -188,9 +196,14 @@ function GlobalSearchContent({
 		React.useState<SelectedWeapon | null>(
 			resolveInitialWeapon(initialWeaponId, t),
 		);
+
 	const inputRef = React.useRef<HTMLInputElement>(null);
+	const prefixInputRef = React.useRef<HTMLInputElement>(null);
 	const listBoxRef = React.useRef<HTMLDivElement>(null);
 	const modifierKeyRef = React.useRef(false);
+
+	const [isPrefixEditable, setIsPrefixEditable] = React.useState(false);
+	const [editablePrefix, setEditablePrefix] = React.useState("");
 
 	const handleClickCapture = (e: React.MouseEvent) => {
 		modifierKeyRef.current = e.metaKey || e.ctrlKey;
@@ -264,14 +277,42 @@ function GlobalSearchContent({
 	const handleSearchTypeChange = (value: string) => {
 		setSearchType(value as SearchType);
 		setSelectedWeapon(null);
+		setIsPrefixEditable(false);
+		setEditablePrefix("");
 	};
 
 	const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Backspace" && query === "") {
+			e.preventDefault();
+			setIsPrefixEditable(true);
+			setEditablePrefix("");
+			prefixInputRef.current?.focus();
+			return;
+		}
+
 		const currentResults = searchType === "weapons" ? weaponResults : results;
 		if (e.key === "ArrowDown" && currentResults.length > 0) {
 			e.preventDefault();
 			listBoxRef.current?.focus();
 		}
+	};
+
+	const handlePrefixChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const value = e.target.value;
+		setEditablePrefix(value);
+		if (!value.endsWith(":") && !value.endsWith(" ")) return;
+
+		const typedPrefix = value.slice(0, -1);
+		const matchedType = SEARCH_TYPES.find(
+			(type) => SEARCH_TYPE_TO_PREFIX[type] === typedPrefix,
+		);
+		if (!matchedType) return;
+
+		setSearchType(matchedType);
+		setSelectedWeapon(null);
+		setIsPrefixEditable(false);
+		setEditablePrefix("");
+		inputRef.current?.focus();
 	};
 
 	const handleDestinationSelect = () => {
@@ -302,15 +343,29 @@ function GlobalSearchContent({
 
 	return (
 		<div onClickCapture={handleClickCapture}>
-			<Input
-				ref={inputRef}
-				className={styles.input}
-				placeholder={t("common:search.placeholder")}
-				value={query}
-				onChange={(e) => setQuery(e.target.value)}
-				onKeyDown={handleInputKeyDown}
-				icon={<Search className={styles.inputIcon} />}
-			/>
+			<div className={styles.inputContainer}>
+				<input
+					ref={prefixInputRef}
+					className={styles.inputPrefix}
+					type="text"
+					value={
+						isPrefixEditable
+							? editablePrefix
+							: `${SEARCH_TYPE_TO_PREFIX[searchType]}:`
+					}
+					readOnly={!isPrefixEditable}
+					onChange={handlePrefixChange}
+				/>
+				<Input
+					ref={inputRef}
+					className={styles.input}
+					placeholder={t("common:search.placeholder")}
+					value={query}
+					onChange={(e) => setQuery(e.target.value)}
+					onKeyDown={handleInputKeyDown}
+					icon={<Search className={styles.inputIcon} />}
+				/>
+			</div>
 			<div className={styles.searchTypeContainer}>
 				<RadioGroup
 					value={searchType}

--- a/app/components/layout/GlobalSearch.tsx
+++ b/app/components/layout/GlobalSearch.tsx
@@ -281,6 +281,24 @@ function GlobalSearchContent({
 		setEditablePrefix("");
 	};
 
+	const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const value = e.target.value;
+		const separatorMatch = value.match(/^([a-zA-Z]+): /);
+		if (separatorMatch) {
+			const typedPrefix = separatorMatch[1];
+			const matchedType = SEARCH_TYPES.find(
+				(type) => SEARCH_TYPE_TO_PREFIX[type] === typedPrefix,
+			);
+			if (matchedType) {
+				setSearchType(matchedType);
+				setSelectedWeapon(null);
+				setQuery(value.slice(separatorMatch[0].length));
+				return;
+			}
+		}
+		setQuery(value);
+	};
+
 	const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === "Backspace" && query === "") {
 			e.preventDefault();
@@ -367,7 +385,7 @@ function GlobalSearchContent({
 					className={styles.input}
 					placeholder={t("common:search.placeholder")}
 					value={query}
-					onChange={(e) => setQuery(e.target.value)}
+					onChange={handleQueryChange}
 					onKeyDown={handleInputKeyDown}
 					icon={<Search className={styles.inputIcon} />}
 				/>


### PR DESCRIPTION
QoL improvement for GlobalSearch that allows quick switching between categories without needing to click on the radio buttons.

When the main input is empty, backspace will shift focus onto the prefix input. When a prefix is typed in, typing `:` or space will switch the search type and move focus back to the main input.

https://github.com/user-attachments/assets/56dc4729-93f4-46fa-af53-c73067a91f77

