### PR TITLE
Stronghold Article "May + June 2026 LANs"

### DIFF
--- a/content/articles/may-june-2026-LANs.md
+++ b/content/articles/may-june-2026-LANs.md
@@ -1,0 +1,170 @@
+---
+title: "May + June 2026 LANs"
+date: 2026-05-01
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+#### *Start the summer season with some travel plans to your nearest local—also, get the lowdown on April’s LAN Championship Showdown 2026 while you’re here*
+
+<img width="1200" height="630" alt="May + June 2026 LANs" src="https://github.com/user-attachments/assets/ecf6bb81-26fe-43e0-88a8-ab6b9b144fcb" />
+
+As May and June approach, and schedules become freer for many of us with the arrival of summer break, the LANs, too, adapt to the calendar and become bigger. With North America’s LAN Championship Showdown season now passed, a host of new LANs can take the spotlight. 
+
+We’ll take a moment to appreciate the *gravity* of 2026’s LCS’s transformation from its debut last year, but before we discuss the past, let’s see what the future has in store\!
+
+## **May 2026**
+
+### **Mile High Dive \#1: First Ascent \- May 2nd, 2026 (Colorado, United States)**
+
+The Long Tree Hub is hosting the next iteration of Colorado’s regional-area LAN, Mile High Dive\! Located at the same venue as Rocky Mountain Splatdown, The Lone Tree Esports Lounge, the entry fee will be a total of $15 for competitors ($5 venue fee, $10 tournament fee which is put into the prize pool). Spectator passes are $5. 
+
+In order to play, participants need to bring: Nintendo Switch (no Nintendo Switch 2s), Splatoon 3, controller, and charging cords. TOs recommend bringing your own 3.5mm headset with mic and Switch dock with HDMI and LAN cables. If you’re able to bring extra USB LAN adapters, it would be appreciated\! Look for a team and see who else is going in the [Mile High Dive (CO Splatoon) Discord](https://discord.gg/yNhkGd6HGF).
+
+Mile High Dive \#1: First Ascent opens the doors to its inaugural event at The Lone Tree Hub community center at 1 PM on Saturday, May 2, and matches will begin shortly after, at 2 PM. For tournament rules, guidelines, maplist, and registration, check out the [start.gg](https://www.start.gg/tournament/mile-high-dive-1-first-ascent/details) page\!
+
+### **SplashGo\! \#13 \- May 2–3rd, 2026 (Tokyo, Japan)**
+
+Gearing up for its next iteration is the SplashGo\! tournament in Japan\! SplashGo\! is one of the biggest Splatoon 3 LANs worldwide, even larger than Riptide in the West. It is a two-day Turf War-only event that hosts up to 128 teams; last event (\#12) saw 94 teams participate and even had an IPL stream cast in English for accessibility to a broader audience. 
+
+The main spectacle will be a Group Round Robin style event on day 1 into a Single-Elimination Finals bracket on day 2, exclusively for Turf War. Counter stages are in effect, and sets are best of three. Spectators are welcome as well\! This time, Dapple Productions will be providing an [English cast stream](https://www.youtube.com/watch?v=K0jgEtfD7vU), for day one. 
+
+SplashGo\! \#13 will be held at the Tokyo Metropolitan Industrial Trade Center, 5F in Minato City, Tokyo, Japan, starting on Saturday, May 2, 2026, and run through Sunday the 2nd. Registration and further inquiries can be found on the event’s official page, [Ikanakama.ink](https://ikanakama.ink/events/19112).
+
+### **Squid-Waukee \#8 Spring 2026 \- May 9th, 2026 (Wisconsin, United States)**
+
+Squid-Waukee, Wisconsin’s free-to-play LAN local, returns in the month of May and is ready to welcome players of all ages and skill levels to attend. Interested in learning more or attending? Join the [SquidWest (Midwest Splatoon Players)](https://discord.com/invite/Acv9qH6) Discord\!
+
+All attendees need to bring for the 2v2 event is a Nintendo Switch (Switch 2s are not permitted for this event), copy of the game, and a controller. Sign up through the dedicated Discord event link, [here](https://discord.com/events/209679304487993345/1477396235160785079). It would help the TOs considerably if anyone prospective about attending marked themselves as “Interested” on the event\! 
+
+<img width="1000" height="562" alt="squid-waukee" src="https://github.com/user-attachments/assets/038f371d-bbce-4fbf-b067-9c1530b4c067" />
+
+*Squid-Waukee \#8 Spring 2026 is at a new venue this time around\!*
+
+Squid-Waukee \#8 Spring 2026 is hosted at the West Allis Public Library in West Allis, Wisconsin, on Saturday, May 9th, from 11:30 AM \- 3 PM. Keep up to date with all Squid-Waukee and other Wisconsin-related Splatoon events by following the [Squid-Waukee Bluesky](http://@squidwaukee.bsky.social) page. 
+
+### **\[CANCELED LAN\] Bread Basket: Rising \- May 16–17th, 2026 (Edmonton, Canada)**
+
+Looking for a LAN that offers more than just Splatoon? Bread Basket: Rising is a fighting game major in Edmonton, Alberta spanning an entire weekend in May. What used to just be a Super Smash Bros. tournament has grown to include Guilty Gear: Strive, Rivals of Aether 2, Tekken 8, Splatoon 3, and more.
+
+Although the event runs yearly, Bread Basket: Rising (2026) has been canceled, per the TOs. The start.gg page and French Bread Gaming official website still list the event as ongoing, but it will **not be taking place this year**. 
+
+### **MomoCon 2026 \- May 21–24th, 2026 (Georgia, United States)**
+
+A major anime, gaming, comics, and animation convention held in Georgia, MomoCon has been a staple event in the United States since the early 2000s. Because of its scale being that much larger than just a video game event, it brings in *a massive audience*; last year, they hosted over 59,000 attendees and anticipate even more in 2026\. And you’ll find a Splatoon 3 tournament there, as well as a [Pop-LANtis](https://poplantis.com/) table\! 
+
+Setups will be provided for Splatoon, but players will need to still bring their Switch, controller, and copy of the game. Pools begin on Friday, May 22nd at 10 AM, with Silver Bracket anticipated to begin at 4 PM the same day and conclude on Saturday morning. It will be followed up by the Redemption Bracket and Top Cut/Gold Bracket later on Saturday. While MomoCon lasts four days, Splatoon is only on Friday and Saturday. 
+
+<img width="1000" height="559" alt="momoconbanner" src="https://github.com/user-attachments/assets/bfc71130-9566-46a4-a4a0-5ac5a190b153" />
+
+While not playing in the tournament, MomoCon has plenty to offer, from cosplay, live entertainment, a star-studded guest list, workshops, to a maid cafe. [Wonder Festival](https://wonfes.us/) will also have its first appearance in the United States at MomoCon. Admission to Wonder Festival is included with MomoCon passes, so why not take a gander at Japan’s renowned figure and model craftsmanship fest?
+
+MomoCon 2026 takes place between Thursday, May 21st and Sunday, May 24th. Admission passes must be purchased on [MomoCon’s official website](https://www.momocon.com/registration/), and then those wanting to partake in tournaments must register on [start.gg](https://www.start.gg/tournament/momocon-2026-5/details). IPL will be streaming the Splatoon 3 tournament this year on their [Twitch](https://www.twitch.tv/iplsplatoon) channel\!
+
+### **Chi-Shoals \#42 (Salmon Run Edition) \- May 23rd, 2026 (Illinois, United States)**
+
+Chi-Shoals, Illinois’ long-running Splatoon LAN, has its 42nd iteration as a Salmon Run special event\! Organized by SquidWest and hosted at the Harold Washington Library in Chicago, Chi-Shoals is open to players of all ages and skills.
+
+Following its much-busier predecessor, which was the LAN Championship Showdown qualifier, the Salmon Run edition is geared to be a more lax event, but still brings plenty of competition. Participants need to bring their Nintendo Switch, Splatoon 3, headset, and a controller. The main event will be streamed on the [SquidWest Twitch Channel](https://twitch.tv/squidwest)\!
+
+Chi-Shoals \#42 (Salmon Run Edition), on Saturday, May 23rd, precedes Chi-Shoals \#43, which will be the Gamer’s Universe edition\! More information can be found on SquidWest’s [Challonge](https://challonge.com/communities/SquidWest) page or [Sendou.ink](https://sendou.ink/calendar/4599) page.
+
+### **LAN of 10,000 Lakes \#2 \- May 23rd, 2026 (Minnesota, United States)**
+
+Having debuted just last March, LAN of 10,000 Lakes returns to the Twin Cities area in Minnesota\! Located in the RTM Gaming Lounge in a wheelchair-accessible office building, it boasts a large projector screen for an enhanced spectator experience, and even has extra games on the side to play\!
+
+Participants need to bring their Switch and game, controller, and headset in order to play. Those who bring their own Switch dock and allow others to use it for the event will receive $2 off on their registration fee. Switch 2 owners can participate, but will **need** to bring their own Switch 2 dock and LAN cables to use it.
+
+LAN of 10,000 Lakes \#2 will be held on Saturday, May 23rd, 2026, at the RunTheMix (RTM) Gaming Lounge in Roseville, Minnesota. Venue doors open at 12 PM; the preliminary Swiss bracket starts at 1 PM and is anticipated to run until 5-6 PM. [Start.gg](https://www.start.gg/tournament/lan-of-10-000-lakes-2/details) has venue directions and entrance instructions, as well as tournament rules, the Discord server invitation, and registration.
+
+### **Little Dapple: Return of the Gala \- May 23rd, 2026 (New York, United States)**
+
+New York’s Big Dapple wants you to come back for a casual, one-day LAN featuring friendlies, practice, coaching, and if enough players show up to throw down, a light tournament. Intended to be smaller in size than Big Dapple, as a follow up from the Golden Gala LCS qualifier in April, all for the purpose of preparing for the upcoming regional, Gridlock\!
+
+<img width="1000" height="500" alt="littledapplebanner" src="https://github.com/user-attachments/assets/bb685754-5544-483f-8369-4ea394c0b014" />
+
+*There are already 10 attendees registered for Little Dapple: Return of the Gala as of May 1, 2026, so a tournament is sounding more likely by the day\!*
+
+Attendees are encouraged to visit Little Dapple’s [start.gg](https://www.start.gg/tournament/little-dapple-return-of-the-gala-1/details) page for commute routes and other transportation details to the venue, which is different from the OS NYC hub that Metro Ink regulars have been to. The new location is the newly-opened Gaming Dojo, found at 36-29 Main Street in Flushing, New York.
+
+Switch 1s and Switch 2s are permitted, but those using Switch 2s must bring their docks and adapters, and allow others to use the equipment if needed. Those playing also need their controller, game, and 3.5mm headset. Teams will be made on-site.
+
+Little Dapple: Return of the Gala opens at 1 PM ET on Saturday, May 23rd, 2026 at the Gaming Dojo. The venue closes at 6 PM. Spectator passes are also available, both online and in-person. 
+
+## **Desert Highlands Monthly Tournament \- May 31st, 2026 (New Mexico, United States)**
+
+New Mexico’s newest LAN will also be celebrating its second event, Desert Highlands\! You’ll find this event hosted at Geek Shack, a hobby shop well-loved by the locals. Although the [start.gg](https://www.start.gg/tournament/desert-highlands-monthly-tournament-1/details) page for the event lists May 17 as the LAN date, it is confirmed for May 31st through the [Inklings of Las Cruces Discord](https://discord.com/invite/zpAM3XrRFA).
+
+The tournament format will be a 4v4 Best of 3, with the first game’s mode being selected by vote at the start and the first map chosen at random. The losing team will then pick the map for the next game. Depending on player turnout and voting, Grand Finals may be a Best 5 out of 6 set, which will be determined day-of. 
+
+The Desert Highlands Monthly Tournament of May 2026 starts at 4 PM on Sunday, May 31st at Geek Shack in Las Cruces, New Mexico. Anyone interested in participating in this burgeoning LAN should register through the Discord using the link above\!
+
+## **June 2026**
+
+### **Squidstorm x LeBlánce \- CLUTCH United \- June 6–7th, 2026 (Fellbach, Germany)**
+
+Germany’s bimonthly LAN, SQUIDSTORM, is celebrating its sixteenth iteration in collaboration with LeBlánce\! Hosted at the CLUTCH23 Gaming Bar & Social Space, players can dine and duel in one location—a day pass comes with one free drink\!
+
+The hosts promise participants this: “16 monitors. LAN connection. Two 4v4 matches at the same time. No lag. No excuse.” Battle your way through Best of 3 Swiss rounds into the Playoffs bracket—a podium placement will award a medal, but only first place gets a cup to go with it\! Players need to bring their Nintendo Switch, controller, Splatoon 3, and a dock with LAN adapter and power cable. 
+
+Squidstorm x LeBlánce \- CLUTCH United runs on Saturday and Sunday, June 6–7, 2026\. CLUTCH23’s doors open at 11 AM, and the bracket begins at 12 PM. You will find all of the details, registration, and rules on [start.gg](https://www.start.gg/tournament/squidstorm-x-lebl-nce-clutch-united/details). Can’t make it out? [CLUTCH United’s Twitch](https://twitch.tv/clutchunited) channel will be streaming the event\!
+
+### **Chi-Shoals \#43 (Gamer's Universe) \- June 13th, 2026 (Illinois, United States)**
+
+It’s Chi-Shoals… again\! May through July 2026 features back-to-back-to-back monthly events of Illinois’ LCS-affiliated Splatoon LAN local. The 43rd iteration is called “Gamer’s Universe”. It’s still organized by SquidWest and hosted at the Harold Washington Library in Chicago, and always open to all ages and skill levels\!
+
+Returning back to form after its Salmon Run predecessor, the tournament will be a Groups to Single-Elimination format. Participants need to bring their Nintendo Switch, Splatoon 3, headset, and a controller. The main event will be streamed on the [SquidWest Twitch Channel](https://twitch.tv/squidwest)\!
+
+Chi-Shoals \#43 (Gamer’s Universe) continues the three-month streak on Saturday, June 13th, 2026, from 11 AM–4 PM CT\! More information can be found on SquidWest’s [Challonge](https://challonge.com/communities/SquidWest) or [Sendou.ink](https://sendou.ink/calendar/4600) page. Join the [SquidWest (Midwest Splatoon Players)](https://discord.com/invite/Acv9qH6) Discord server for info, the latest SquidWest news, and commentator opportunities\!
+
+## **LAN Championship Showdown: April 26, 2026**
+
+Preceding all of the above LANs was the LAN Championship Showdown (LCS) on Sunday, April 26th, 2026\. Twelve champion teams from twelve individual LAN locals across North America were invited to the exclusive online tournament to crown the strongest LAN of the land. Built up from its premiere in 2025 with only eight teams, Florida’s GatorLAN at the top, how did 2026 revolutionize the game? 
+
+What’s the lowdown from this showdown? 
+
+These teams represented their region over the five-stream spectacle: 
+
+* [Torontoroka](https://www.start.gg/tournament/torontoroka-2026/details) (Toronto, Ontario) \- **sINKronise**   
+* [SoCallie](https://www.start.gg/tournament/socallie-9-the-glacial-gala/details) (Irvine, California) \- **Deep-Fried Chuds**   
+* [Booyah Bay](https://www.start.gg/tournament/booyah-bay-cable-car-coast-splatoon-3-lan-san-jose-ca/details) (San Jose, California) \- **Shark**   
+* [GatorLAN](https://www.start.gg/tournament/gatorlan-spring-2026/details) (Gainesville, Florida) \- **super g**   
+* [Chi-Shoals](https://challonge.com/chishoals41) (Chicago, Illinois) \- **Overseer**   
+* [Anarchy NoVA](https://www.start.gg/tournament/anarchy-nova-3/details) (Ashburn, Virginia) \- **Dairy Queen Check\!\!**   
+* [SeaBATTLE\!](https://www.start.gg/tournament/seabattle-royale-2026/details) (Seattle, Washington) \- **We aren't practicing**   
+* [Big Dapple](https://www.start.gg/tournament/big-dapple-10-the-golden-gala/details) (New York, New York) \- **Gravity**   
+* [H-Town Splashdown](https://www.start.gg/tournament/h-town-splashdown-7-blastoff/details) (Houston, Texas) \- **BBQ Pork Jambalaya**   
+* [New InkLAN](https://www.start.gg/tournament/new-inklan-6/details) (Waltham, Massachusetts) \- **Z Tier Players**   
+* [Sunset Surge](https://www.start.gg/tournament/sunset-surge-blossom-blitz-2026/details) (Tempe, Arizona) \- **Monsoon Season**   
+* [Don't Flounder at the Function](https://www.start.gg/tournament/don-t-flounder-at-the-function-2-spring-break/details) (Cary, North Carolina) \- **7.8/10 Too Much Ink** 
+
+<img width="586" height="880" alt="LCStreams" src="https://github.com/user-attachments/assets/0c7e077b-ebbc-4ad0-8695-04e3a54e28b6" />
+
+SplatoonTourney and its four Twitch channels (SplatoonTourney 1, 2, 3, and 4\) simultaneously streamed every set in the tournament, with casters from each LCS qualifier represented. This was during one of the busiest weekends for Competitive Splatoon, running alongside the Global Gauntlet 1 Finals, Splatoon 3 North American League, LUTI Division 2 Finals, CCA’s Pacifink Collegiate Invitational, and more. 
+
+Out of 22 Best of 5 sets total, eight sets went to a game five (over 1/3rd of all sets), seven went to a game four, and the other seven were a 3-0 knockout—with two of them saved for Winner’s Finals and Grand Finals. 
+
+[The results](https://sendou.ink/to/3655/results) mostly reflected the teams’ assigned seeds, with first and second place going to seeds \#1 and \#2 respectively, and third place going to seed \#4, while seed \#3 took fourth place. 
+
+Gravity (representing Big Dapple) was the team to watch out for, being entirely composed of NA champions. They had a near-perfect run in the event, only losing one game to GatorLAN’s super g. While GatorLAN didn’t take home the gold two years in a row, they earned a major achievement that no one else could. 
+
+Also, some prize money from Popgun.
+
+<img width="710" height="565" alt="LCSpopgunbet" src="https://github.com/user-attachments/assets/26db7bab-2315-412d-952b-da913ce18700" />
+
+*Since super g’s local is GatorLAN, which is free, Popgun ended up paying the team $100 USD as “gas money”, with the note, “Beat Milkyway \+ Zero in a rainmaker game”.*
+
+By the end of the night, the podium was filled, with these three teams at the top:
+
+1. Gravity (Big Dapple)  
+2. BBQ Pork Jambalaya (H-Town Splashdown)  
+3. super g (GatorLAN)
+
+The list of credits for such a branched-out event runs long, as does all of the hard work from the TOs, players, mic talent, streamers, and producers. The credits roll from the event can be found on [SplatoonTourney’s Bluesky](https://bsky.app/profile/splatoontourney.bsky.social/post/3mkkyrzcoy22s), and while you’re there, Falco’s [“Reflections and Thank Yous thread”](https://bsky.app/profile/falcoflyer.bsky.social/post/3mkikl3jrok2o) provides not only gratitude to everyone involved, but also links to find them. 
+
+With 2026 bringing a boom of new LANs to more regions than ever before, remember to support your locals and your TOs, so they can keep raising the line for Competitive Splatoon and your viewer experience\! 
+
+Original Posting Date: May 1, 2026 at [Splatoon Stronghold](https://www.splatoonstronghold.com/news/may-june-2026-lans).
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add article from Splatoon Stronghold, repost of https://www.splatoonstronghold.com/news/may-june-2026-lans