### PR TITLE
Add `/api/tournament/:id/streams` route

### DIFF
--- a/app/features/api-public/routes/tournament.$id.streams.ts
+++ b/app/features/api-public/routes/tournament.$id.streams.ts
@@ -1,0 +1,80 @@
+import { sql } from "kysely";
+import { jsonArrayFrom } from "kysely/helpers/sqlite";
+import type { LoaderFunctionArgs } from "react-router";
+import { z } from "zod";
+import { db } from "~/db/sql";
+import { notFoundIfFalsy, parseParams } from "~/utils/remix.server";
+import { id } from "~/utils/zod";
+import type { GetTournamentStreamsResponse } from "../schema";
+
+const paramsSchema = z.object({
+	id,
+});
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+	const { id } = parseParams({
+		params,
+		schema: paramsSchema,
+	});
+
+	const tournament = notFoundIfFalsy(
+		await db
+			.selectFrom("Tournament")
+			.select([
+				jsonArrayFrom(
+					db
+						.selectFrom("LiveStream")
+						.leftJoin(
+							"TournamentTeamMember",
+							"TournamentTeamMember.userId",
+							"LiveStream.userId",
+						)
+						.leftJoin(
+							"TournamentTeam",
+							"TournamentTeam.id",
+							"TournamentTeamMember.tournamentTeamId",
+						)
+						.select([
+							"LiveStream.userId",
+							"LiveStream.twitch",
+							"LiveStream.viewerCount",
+						])
+						.where("TournamentTeam.tournamentId", "=", id),
+				).as("playerStreams"),
+				jsonArrayFrom(
+					db
+						.selectFrom("LiveStream")
+						.select(["LiveStream.twitch", "LiveStream.viewerCount"])
+						.where(
+							sql<boolean>`"LiveStream"."twitch" IN (SELECT value FROM json_each("Tournament"."castTwitchAccounts"))`,
+						),
+				).as("castStreams"),
+			])
+			.where("Tournament.id", "=", id)
+			.executeTakeFirst(),
+	);
+
+	const playerStreams: GetTournamentStreamsResponse =
+		tournament?.playerStreams.map((stream) => ({
+			type: "PLAYER",
+			userId: stream.userId!,
+			platform: "TWITCH",
+			channelId: stream.twitch!,
+			viewerCount: stream.viewerCount!,
+		})) ?? [];
+
+	const castStreams: GetTournamentStreamsResponse =
+		tournament?.castStreams.map((stream) => ({
+			type: "CAST",
+			platform: "TWITCH",
+			channelId: stream.twitch!,
+			viewerCount: stream.viewerCount!,
+		})) ?? [];
+
+	const result: GetTournamentStreamsResponse = [
+		...playerStreams,
+		...castStreams,
+	].sort((a, b) => b.viewerCount - a.viewerCount);
+
+	return Response.json(result);
+};

--- a/app/features/api-public/schema.ts
+++ b/app/features/api-public/schema.ts
@@ -273,18 +273,27 @@ export interface GetCastedTournamentMatchesResponse {
 	 */
 	current: Array<{
 		matchId: number;
-		channel: TournamentCastChannel;
+		channel: TournamentStreamChannel;
 	}>;
 	/*
 	 * Matches that are locked to be casted.
 	 */
 	future: Array<{
 		matchId: number;
-		channel: TournamentCastChannel;
+		channel: TournamentStreamChannel;
 	}>;
 }
 
-type TournamentCastChannel = {
+/** GET /api/tournament/{tournamentId}/streams */
+export type GetTournamentStreamsResponse = Array<
+	{
+		platform: "TWITCH";
+		channelId: string;
+		viewerCount: number;
+	} & ({ type: "PLAYER"; userId: number } | { type: "CAST" })
+>;
+
+type TournamentStreamChannel = {
 	type: "TWITCH";
 	/**
 	 * @example "iplsplatoon"

--- a/app/features/api-public/schema.ts
+++ b/app/features/api-public/schema.ts
@@ -273,16 +273,24 @@ export interface GetCastedTournamentMatchesResponse {
 	 */
 	current: Array<{
 		matchId: number;
-		channel: TournamentStreamChannel;
+		channel: TournamentCastChannel;
 	}>;
 	/*
 	 * Matches that are locked to be casted.
 	 */
 	future: Array<{
 		matchId: number;
-		channel: TournamentStreamChannel;
+		channel: TournamentCastChannel;
 	}>;
 }
+
+type TournamentCastChannel = {
+	type: "TWITCH";
+	/**
+	 * @example "iplsplatoon"
+	 */
+	channelId: string;
+};
 
 /** GET /api/tournament/{tournamentId}/streams */
 export type GetTournamentStreamsResponse = Array<
@@ -292,14 +300,6 @@ export type GetTournamentStreamsResponse = Array<
 		viewerCount: number;
 	} & ({ type: "PLAYER"; userId: number } | { type: "CAST" })
 >;
-
-type TournamentStreamChannel = {
-	type: "TWITCH";
-	/**
-	 * @example "iplsplatoon"
-	 */
-	channelId: string;
-};
 
 /** GET /api/tournament-match/{matchId} */
 

--- a/app/features/api-public/schema.ts
+++ b/app/features/api-public/schema.ts
@@ -293,6 +293,7 @@ type TournamentCastChannel = {
 };
 
 /** GET /api/tournament/{tournamentId}/streams */
+
 export type GetTournamentStreamsResponse = Array<
 	{
 		platform: "TWITCH";

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -340,6 +340,10 @@ export default [
 				"features/api-public/routes/tournament.$id.starting-brackets.ts",
 			),
 			route(
+				"/tournament/:id/streams",
+				"features/api-public/routes/tournament.$id.streams.ts",
+			),
+			route(
 				"/tournament/:id/teams/:teamId/add-member",
 				"features/api-public/routes/tournament.$id.teams.$teamId.add-member.ts",
 			),


### PR DESCRIPTION
Closes #3017

## Summary

This adds a route to list all active live streams (like the Streams tab) in the API.

## Routes changed

New: `/api/tournament/:id/streams`
