### PR TITLE
Add super sea snail badge commission

### DIFF
--- a/app/features/badges/homemade.json
+++ b/app/features/badges/homemade.json
@@ -1542,5 +1542,9 @@
 	"zekkocup": {
 		"displayName": "Zekko Cup",
 		"authorDiscordId": "1320944066002681876"
+	},
+		"superseasnails": {
+		"displayName": "Super Sea Snails",
+		"authorDiscordId": "534502084134043648"
 	}
 }


### PR DESCRIPTION
## Summary

adding super sea snail badge commision for noctis

## Notes

Awarded for winning 10 x tournaments hosted by Barnacle and Dime

