### PR TITLE
Stronghold Article "SWS26 Recap: GG2 Q1 SQ S11 Finale"

### DIFF
--- a/content/articles/sws26-recap-gg2-q1-sqs11-finale.md
+++ b/content/articles/sws26-recap-gg2-q1-sqs11-finale.md
@@ -1,0 +1,89 @@
+---
+title: "SendouQ Season 11 Finale (SWS26 Recap: Global Gauntlet 2, Qualifier 1) "
+date: 2026-05-30
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+#### *The Sendou.ink x IPL x AREA CUP collaboration adds new stakes to a quarterly major*
+
+<img width="1200" height="675" alt="SWS26Recap_SQS11F-GG2Q1" src="https://github.com/user-attachments/assets/d71c8459-7201-4b88-91b4-91397a87d2a7" />
+
+On Saturday, May 23rd, 2026, Sendou.ink’s 11th seasonal Splatoon major, the SendouQ Season 11 Finale, ran with a new twist: in collaborating with Inkling Performance Labs (IPL) and AREA CUP, the Season 11 Finale was converted into the first of two qualifiers for the upcoming Second Edition Global Gauntlet. The top three teams from this event would be the first to earn their way to the GG2 Finals on June 5th.
+
+Since the schedule for the Second Edition Global Gauntlet had to move everything up one week, rather than have the qualifier on the same day as the SendouQ Finale and the North American League, the Finale became the GG2 Qualifier 1 event. 
+
+This time around, the event had a new addition: one week prior was the brand-new SendouQ Season 11 Finale Qualifier, in which the top four teams from *that* event were invited to the Season 11 Finale, in addition to the top 12 ranked teams from the SendouQ season leaderboard. 
+
+As far as this event goes, it still remained a Splat Zones-only tournament, starting with a Best of 5 Groups Stage in which the top two teams per group advanced to the Top Cut. In the single-elimination Top Cut, Round 1 was a Best of 5, and the Semifinals and Finals to follow were Best of 7\. 
+
+The English commentary crew included Falco and Popgun for block 1, and Kbot and Rissa for block 2, with Pipedream operating the spectator cam. Hemi and Razzy were providing a Japanese stream, with DaiP on the spec cam.
+
+## **Top Cut Round 1: The avengers vs. Poltergeist (3–0)**
+
+The avengers vs. Poltergeist was a matchup waiting to continue the story from the SendouQ Season 11 Finale Qualifier. Both teams entered the season finale tournament from the qualifier from opposite ends of the bracket: The avengers from the Loser’s Bracket, and Poltergeist from the Winner’s Bracket.
+
+The avengers, seed \#14, went 2–1 in sets, 3–0’ing and upsetting seed \#3 王KING王 and seed \#6 DOOM DESIRE, only dropping games to seed \#11 healthy diet food groups, losing the set 2–3. Poltergeist, seed \#10, upset seed \#7 37 sexy boys team 2 3–0, lost 1–3 to seed \#2 ezmd, and lost in a 1–3 upset to seed \#15 aple 🍎. 
+
+Their set began at Mincemeat Metalworks. The avengers capped the zone first, getting to 69 before Poltergeists’s Triple Inkstrikes snatched the zone. Poltergeist was quickly wiped out, and they struggled to take the zone at all for the rest of the game—when they could manage to get out of their base. Halfway through the match timer, The avengers knocked out for the win. 
+
+Game two saw The avengers bring in a Bamboozler 14 Mk I, swapping Killer Wail 5.1 weapons from the previous game’s Rapid Blaster Pro Deco. In the opening clash for the zone at Urchin Underpass, both teams went down two players, and Poltergeist won the objective. The early advantage would not save them down the road, as they once more struggled to keep all four players up on the field, losing a second time in a knockout.
+
+<img width="1000" height="562" alt="TCR1_Urchin" src="https://github.com/user-attachments/assets/d89bdf1b-f888-4e82-b6b7-87ad070412b9" />
+
+*Poltergeist’s Custom Blaster player tried to save the game, but was just frames shy of capping the zone before The avengers knocked out.*
+
+Hagglefish Market was the last map of the set; once more, Poltergeist got the zone first, but could not hold onto it for long. They fared much better this game, even wiping The avengers out at one point, but only delayed The avengers’ third knockout win. Poltergeist tied with 王KING王, Epitaph, and So What for 5th place.
+
+## **Top Cut Semifinals: snails vs. King Hatano Fanclub (4–1)**
+
+Snails and King Hatano Fanclub were the other two teams who made their way into the Finale from the Qualifier event, making the Top Cut stream exclusive to the Finale Qualifier teams. The players on these teams shouldn’t surprise anyone, with snails being PxG, and King Hatano Fanclub being a Fruittella pickup with tung tung.
+
+Snails, as expected, arrived at the Semifinals without losing a single game and KOing each match. King Hatano Fanclub’s record was not too far off, winning all but one game, their perfect run stopped by Sun-Eater in the Group Stage.
+
+Um’ami Ruins was the map for game one. Snails took both zones before any players were splatted. The teams took turns having the upper hand; King Hatano Fanclub was in the lead for most of the game. Snails, who had been playing a slow, steady game so far, turned the game around with a delayed wipeout. They moved up to lock out, took the lead, and seconds later, won in a knockout.
+
+Flounder Heights, another double-zone map, had a wipeout within the first minute, putting King Hatano Fanclub in a very unfavorable situation early on. They managed to stop snails after 80 ticks by dividing the team and taking down two players. Snails got back in, and Noah splatting two players with one E-liter 4K shot let snails hold the zone longer, finally stopped at 9 by an Ink Vac shot. The game ended 91–67 for snails.
+
+<img width="1000" height="562" alt="TCSF_Um&#39;ami" src="https://github.com/user-attachments/assets/df1763f1-6eac-4458-8f7a-3afc06126313" />
+
+*Grey, facing the camera, calls “This way\!” to his teammates before turning around and getting a direct shot on an enemy super jump, earning his team the delayed wipeout.*
+
+Game three, at Urchin Underpass, was the only time any players between both teams changed weapons, and it was just Noah switching to a Heavy Splatling. Snails was primed to easily knock out, but No Motion jumped in with a Triple Splashdown, splatting two of snails’ players, leading to their delayed wipeout and stopping them at 11\. This was only a setback for snails, and one minute later, they knocked out a victory again.
+
+Back to double-zone maps, Undertow Spillway was the first time King Hatano Fanclub took the zone before snails. They brought their lead to 28 before losing three players, letting snails in. Snails’ hold let them take the lead just barely—King Hatano Fanclub tied with snails on their next push, but lost the zone. When they bounced back, they took a slight lead over snails, and in overtime, got their first win, 79–74.
+
+Snails was not afraid to put pressure on King Hatano Fanclub at Mahi-Mahi Resort, moving up onto the platform multiple times to lock out. Like in game one, King Hatano Fanclub struggled to take the zone, let alone hold it, never getting more than 20 points. With over two minutes left, snails knocked out and advanced to the Finals.
+
+## **Top Cut Finals: snails vs. The avengers (4–0)**
+
+Appearing twice each during the Top Cut stream, the final set came down to snails and The avengers. Between the previous set ending and this one beginning, the stream switched to ezmd’s Semifinals game seven against The avengers, a sneak peek at who would end up facing snails for the gold. 
+
+Returning to Um’ami Ruins for game one, again snails captured both zones before any squids were splatted. The avengers could hardly move beyond the ramp leading into their base due to snails’ offensive defense. In a last-ditch effort, one player snuck onto the zones to Triple Splashdown, but was caught and splatted, resulting in a wipeout on The avengers as snails knocked out to win.
+
+Urchin Underpass again saw The avengers try to distract snails with 3/4ths of the team while the Triple Splashdown user went for the zone, which again ended with The avengers in a difficult spot. Yet they tried it a third time, succeeding to only neutralize the zone before snails captured it again. Once more, snails won with a 100-to-0 knockout, just one second longer than the previous game.
+
+
+<img width="1000" height="562" alt="TCF_Um&#39;ami" src="https://github.com/user-attachments/assets/a24ce771-dc25-42a4-88bd-2f52094f8c03" />
+*Three teammates down and points ticking for snails, King Hatano Fanclub’s Tako rushes to the nearest zone to Triple Splashdown, only to be met with a wipeout.*
+
+For a change of scenery, the teams went to Wahoo World. Tako scored a double on snails, bringing The avengers to their first points of the set. By the end of the first minute, The avengers had the lead, and it was snails desperately using Triple Splashdown on the zone to cap it. Steadily, snails pushed into the zone, regaining control, and eventually the lead, for another knockout.
+
+Brinewater Springs was the closest game between the two; in the first few minutes, both teams traded the zone and lead back and forth. The avengers had a much higher paint output than snails, able to stop them at 6 ticks to go, and snails’ response was to send Gos to spawncamp them. The avengers broke back into the zone; just two ticks from the lead, snails stopped them at 8, and the final score settled at 94–92, to snails.
+
+<img width="1000" height="562" alt="TCF_snails" src="https://github.com/user-attachments/assets/dae476c9-3107-400b-932f-8a541ce9bb25" />
+
+With the conclusion of the Season 11 Finale, Grey, Gos, and Noah have all won three SendouQ Season Finales in a row, just adding more prestige to PxG’s already heavily-decorated name. Yeti’s achievements in the tournament were far from anything to scoff at, either: 
+
+**“\[Yeti\] contributed \[...\] 51 splats and assists in Finals ALONE. Across four games. If that’s not impressive, and also not MVP-worthy, I don’t know what precisely is.” —Kbot, on Yeti’s N-ZAP ‘85 gameplay in Finals**
+
+As the SendouQ Season 11 Finale acted as Qualifier 1 for the Second Edition Global Gauntlet, the top three teams from this event—snails, The avengers, ezmd—were given tickets to the GG2 Finals. However, one of the teams declined the offer, so the GG2 Qualifier 2 will instead be offering spots at the Finals to the top four teams of the event, rather than the top three. 
+
+At the time of writing, the only team registered for the GG2 Finals is PxG. Who else will be representing the West? Which teams will AREA CUP choose for Japan’s roster? 
+
+Stay tuned, because we’ll be finding out soon enough\!
+
+Original Posting Date: May 30, 2026 at [Splatoon Stronghold](https://www.splatoonstronghold.com/news/sws26-recap-gg2q1-sqs11f).
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add article from Splatoon Stronghold; "SendouQ Season 11 Finale (SWS26 Recap: Global Gauntlet 2, Qualifier 1)", repost of https://www.splatoonstronghold.com/news/sws26-recap-gg2q1-sqs11f