### PR TITLE
Stronghold Article "SWS26 GG2 Finals"

### DIFF
--- a/content/articles/sws26-recap-GG2-finals.md
+++ b/content/articles/sws26-recap-GG2-finals.md
@@ -1,0 +1,245 @@
+---
+title: "SWS26 Recap: Global Gauntlet 2 Finals"
+date: 2026-06-19
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+#### *With all but one team being new to the Global Gauntlet Finals, does the West do better or worse than last time?*
+
+<img width="1200" height="675" alt="SWS26Recap_GG2F" src="https://github.com/user-attachments/assets/dae751de-12f4-4c83-ae65-918ced3750a9" />
+
+On Friday, June 5th and Saturday June 6th, the Second Edition Global Gauntlet Finals concluded the warm-up arc leading up to the Splat World Series Finals. Four qualifying events and one previous GG Finals created a measurable journey streamed live in two languages by Inkling Performance Labs (IPL) and AREA CUP.
+
+The English stream was split into two commentary blocks, beginning with Cyren and Magic and ending with Kbot and Zach. Pat, Sasu, and Fufu provided an analysis desk panel and pre-show. Ely operated the spectator camera for the IPL stream. 
+
+The Japanese stream was hosted by Hemi and Momo, the captain from Japan’s team swing from the First Edition Global Gauntlet. Vital provided the spectator camera POV for AREA CUP’s stream.
+
+## **The Teams**
+
+While many of the same players were returning to the Global Gauntlet, one team stood out from the rest: the West’s PxG, the only team coming back under the same name, with the same roster. All other teams were newly formed, with a mix of players both new and returning.
+
+**The teams and players who made up the West’s roster:** 
+
+1. PxG: Grey, Gos, Noah (Yu\_Liter), Jordan (soulja)  
+2. Milky Way: bran, .q, ice, Jared  
+3. Rinascita: Volty, Yeti, y0shell, phoenix  
+4. Crickets: Silver, kiki, Mino, Jay  
+5. Healbook: Jovan, prosper, Len., adapt, Cakes  
+6. New Meta: Isabel, Lucas, Storm, Homengous, Landon
+
+**The teams and players who made up Japan’s roster:** 
+
+1. Always Here: Goyame, Hisatsurukou, Sena, suemaru  
+2. CutieNK: tkf, Naenae, 9ray, Kae  
+3. King of Ham: Todo, Inaten, Sofu, Tanaha  
+4. mellow good: Wolbo, Grandroll (Garandou), Shuta, Shito  
+5. Yamato Spirit: Natyu, Azu, Gehorin, Renorua  
+6. Vacuum World: SAMURAI KASATO (Kasato), Hitokuchi, Chiaki, Utan
+
+Originally, The avengers and ezmd were meant to play for the West after qualifying from the SendouQ Season 11 Finale, but both declined the offer. IPL invited SWS25 veteran Healbook (who participated as FreeFlow) to the West’s roster. 
+
+## **The Gauntlet**
+
+The main event, “The Gauntlet”, was a six-round, Best of 5 Round Robin where Western teams only faced Japanese teams, to maximize playing time with the opposite region.
+
+Like the Global Gauntlet Qualifiers, the Finals were a Splat Zones-only tournament with all stages legal. The main deviation from the norm is the strike/select system:
+
+* When the set begins, both teams take turns banning two maps each. The higher seed gets to pick their two maps of choice to ban first.   
+* The first map that the teams play on is randomly selected out of the pool of non-banned maps. The randomly-selected map is **not** banned after game one.  
+* After the first game, the **winning team** bans two more stages. The **losing team** selects the map for the next game.   
+  * This continues after each game until the set ends.  
+* Map bans reset after the set concludes and will not carry into the next set.
+
+On the day of the GG2 Finals, a few teams between both regions had some last-minute roster changes as players were unavailable. For PxG, this saw Basil—Moonlight’s E-liter 4K player—subbing in for Noah. Crickets brought Thunder (Crush Soda, Azure) in to sub for kiki as a Blaster player. Always Here forfeited their set against New Meta, resulting in a win for New Meta. 
+
+### **Round 1 \- PxG vs. Vacuum World**
+
+The Second Edition Global Gauntlet Finals started at Barnacle & Dime. The first map strikes were Urchin Underpass, Marlin Airport (Vacuum World), Hammerhead Bridge, and Wahoo World (PxG). Both teams mirrored an E-liter 4K and N-ZAP ‘85. 
+
+<img width="1000" height="562" alt="R1_PxGopening" src="https://github.com/user-attachments/assets/df784d92-4172-4261-a123-1e1197d94d28" />
+
+*Noah, PxG’s E-liter 4K player, was temporarily unavailable, so the team recruited Moonlight’s Basil for a few sets after reaching out to both her and Devin4K from ezmd, per soulja’s stream.*
+
+Vacuum World began the match with the zone, holding it through PxG’s Triple Splashdown and outpainting their opposition, who was down two players. The domination was clear: PxG went down three players, then as the clock read 3:41, Vacuum World knocked out. The first victory of the GG2 Finals came in a blinding one minute and 19 seconds, stopping the best of the West. 
+
+Vacuum World banned Manta Maria and Humpback Pump Track. PxG selected MakoMart as the map for game two. The story wouldn’t repeat itself twice in a row.
+
+Back with a vengeance, PxG wiped out Vacuum World in the game’s opening 30 seconds. Vacuum World’s only way to ward PxG away from the zone was to set up a Big Bubbler and Ink Vac, merely delaying PxG’s retake. With a minute left on the clock, PxG returned Vacuum World’s knockout with a win of their own, tying the set.
+
+PxG’s map strikes were Undertow Spillway and Hagglefish Market. Vacuum World selected Robo ROM-en. 
+
+Early in the game, both teams’ primary painters were splatted—Vacuum World won the zone. They set up an early lockout on PxG, able to keep them down multiple players at a time, even wiping them out. Vacuum World earned another fast knockout, this time in just over a minute and a half.
+
+<img width="1000" height="562" alt="R1_Vrobo" src="https://github.com/user-attachments/assets/5ec185d0-ddfb-47a0-8b1b-5e5a65b2a709" />
+
+*Negitorodo mid splat-streak, taking PxG down five players in the span of 15 seconds, helping Vacuum World set up their lockout.* 
+
+Vacuum World banned Lemuria Hub and Bluefin Depot. PxG made the choice to select the double-edged sword, Flounder Heights, as their counterpick, banking on their ability to set up on the zone before their opponent could, knowing retakes were difficult on this map.
+
+It took almost a full minute before points started ticking down more than one at a time; it was Vacuum World in control after taking PxG down two players. PxG did eventually gain control of the zones, but a flank from SAMURA TAN stopped PxG at just 74\. PxG struggled to get back in, losing players every time an opening appeared. The set ended in one last KO, going to Vacuum World, 3–1. 
+
+By technicality, New Meta was the only Western team to win their set in Round 1 (since Always Here forfeited due to… not being there). In a rough opening for the West, the only teams to win games were PxG and Rinascita, only winning one game each.
+
+### **Round 2 \- Milky Way vs. mellow good**
+
+Milky Way had just lost 0–3 against Yamato Spirit, and mellow good was coming from a 3–1 win against Rinascita. Mellow good banned Marlin Airport and Crableg Capital. Milky Way banned Mincemeat Metalworks and Hammerhead Bridge. Both teams brought a Snipewriter 5H, Heavy Splatling, and one kind of Slosher once the random map selection was revealed: Brinewater Springs.
+
+Mellow good’s Reefslider was a major thorn in Milky Way’s side; despite the special’s zone “cheesability” being nerfed, it was still highly effective at capping the zone fast, and did so multiple times, keeping Milky Way from taking the lead. Proceeding into overtime, mellow good had the lead and Milky Way was locking their opponent out. Milky Way was able to take the lead in overtime, winning 94–93. 
+
+<img width="1000" height="562" alt="R2_Mbrinewater" src="https://github.com/user-attachments/assets/de979ea0-da55-4e1b-9512-9676ee409e76" />
+
+*In overtime, Grandroll’s crucial Reefslider got caught on a ledge and missed the zone. Milky Way wiped out mellow good after the blunder and took the lead, winning the game.*
+
+For game two, Milky Way chose to strike Urchin Underpass and Sturgeon Shipyard. Mellow good’s map selection was Mahi-Mahi Resort. 
+
+Grandroll’s Reefslider continued to menace Milky Way, and in return, Milky Way’s Triple Inkstrikes were their answer to quickly retake the zone. Milky Way tried to catch up to mellow good’s lead of 14, but were stopped at 21, and mellow good had the opportunity to increase their lead to 4 in the final seconds. In overtime, Milky Way lost the zone, giving mellow good their first win, 96–79. 
+
+<img width="1000" height="562" alt="R2_Wmahimahi" src="https://github.com/user-attachments/assets/73c80c7e-a563-41c8-b8b8-1c72e5308071" />
+
+*Grandroll just barely slips through Milky Way’s reach, riding the game-winning Reefslider into the zone, capping it in overtime for mellow good.*
+
+Game three saw mellow good choose Lemuria Hub and Humpback Pump Track as their map strikes. Milky Way opted to take mellow good to Undertow Spillway, a map which they have proven to be good at in almost any mode. 
+
+While mellow good had control of the zones first, after taking down two of their players, Milky Way took possession, and shortly afterward claimed the lead, bringing their points to 31 until mellow good was able to stop them. Milky Way ended the game in the set’s first knockout, only 45 seconds ahead of the clock running out. 
+
+Milky Way next banned Robo ROM-en and MakoMart, striking maps that would enable Grandroll’s Reefslider. Mellow good’s map choice was Hagglefish Market. 
+
+Mellow good took the lead from Milky Way early in the game, finally stopped at 21 after Milky Way outpainted them over a neutral zone firefight. Both teams incrementally pushed their scores in turn—mellow good remained ahead. In the second-to-last minute, mellow good went down three players. Milky Way set up a lockout, taking the lead right before wiping out mellow good and knocking out, ultimately winning the set. 
+
+Not just the West’s first win on stream, but this victory also broke Grandroll’s unbroken set win streak starting all the way back with Splat World Series 2025, including all of the SWS26 events. In other Western wins, PxG won their set against Yamato Spirit 3–0, New Meta took one game off of Vacuum World, and Rinascita took King of Ham to a game five set, but lost 2–3. 
+
+### **Round 3 \- CutieNK vs. Rinascita**
+
+CutieNK, so far, had been steamrolling their competition, going 3–0 over both Crickets and Healbook. Rinascita had won at least one game in each of the previous two sets, but no set victories just yet. The spotlight this event was on the JP teams, with each appearing once on IPL’s stream, and Rinascita was the last Western team in the trifecta of themselves, PxG, and Milky Way to be casted. 
+
+Game one’s map strikes from CutieNK were Eeltail Alley and Manta Maria. Rinascita banned Humpback Pump Track and Wahoo World. Having been banned twice so far, the map selection ended up going to Marlin Airport. 
+
+The early game was controlled by Rinascita, taking their lead to 31, supported by a wipeout on CutieNK. A second, delayed wipeout on CutieNK kept them from taking the lead around the three-minute mark. By the halfway point on the clock, CutieNK took the zone from Rinascita while both teams were down two players. Pushing up, they locked Rinascita away from the zone and won the game in a knockout. 
+
+<img width="1000" height="562" alt="R3_Rmarlin" src="https://github.com/user-attachments/assets/8b58f470-77ca-4da9-b472-3ed9c8270b32" />
+
+*From the top rope, Volty swings and trades splats with CutieNK’s Naenae and tkf, bringing both teams down to two players. CutieNK would recover faster, leading to their KO victory.*
+
+Game two went to MakoMart after CutieNK banned the double-zone Flounder Heights and zone-moving Bluefin Depot, both maps which also had considerable heights to contend with.
+
+Like last game, Rinascita’s aggressive opening led them to an early lead into the 30s. Around the 3:30 point, CutieNK’s Triple Inkstrikes and Trizooka stopped Rinascita’s points gain; CutieNK’s strong hold got them the lead about 45 seconds later. Rinascita was able to stop the knockout at the halfway point, but the game still ended in CutieNK’s favor with a KO, just ten seconds slower than the previous set. 
+
+Game three went to a third “M” map in a row, Mincemeat Metalworks, after CutieNK banned Lemuria Hub and Sturgeon Shipyard. CutieNK brought their own Carbon Roller Deco, mirroring Rinascita’s, and paired with the Splattershot, also gave CutieNK a double Trizooka comp. 
+
+<img width="1000" height="562" alt="R3_Cmincemeat" src="https://github.com/user-attachments/assets/6327bb2a-3218-4f99-ad0b-659b24978b74" />
+
+*CutieNK throws three specials—Super Chumps, Triple Inkstrikes, and a Trizooka—at Rinascita to recap the zone, right before Rinascita would have cleared their penalty points.*
+
+CutieNK needed their specials to break Rinascita away from the zone time and time again as they staggered behind their opponent the entire game. Rinascita took CutieNK down three players multiple times. The match went down to the wire—overtime began with half of both teams freshly respawning. CutieNK, with no penalty, needed 11 ticks to win, and they went the distance, closing the set after the 79–78 win. 
+
+Once Round 3 ended, the results for the West included another PxG 3–0, this time over mellow good, joining Milky Way in adding another loss to Grandroll’s previous perfect SWS streak. Milky Way themselves went 2–3 with King of Ham. Crickets and New Meta went 1–3 in their sets. 
+
+### **Round 4 \- PxG vs. King of Ham**
+
+Beginning with Round 4, Kbot and Zach traded places with Cyren and Magic to take over for the second half of the event. PxG was currently on a winning streak, 3–0’ing their two previous opponents. King of Ham was, similarly, on a winning streak, but each set of theirs so far had gone to a game five before deciding the victor. 
+
+By now, Noah had warmed up and joined PxG, letting Basil off the hook. PxG banned Urchin Underpass and Manta Maria after King of Ham banned Undertow Spillway and Mahi-Mahi Resort. Game one went to Scorch Gorge, and immediately all eyes were on King of Ham’s double Splatling (Zink Mini and Torrentz Hydra), triple Big Bubbler \+ Triple Inkstrikes special weapon combo. 
+
+<img width="1000" height="562" alt="R4_Kscorch" src="https://github.com/user-attachments/assets/fc917723-214a-4aa8-a85a-aec1b88d1c18" />
+
+*Spotlight on the weapons King of Ham (right) brought to the match: Mint Decavitator, Zink Mini Splatling, Splat Brella, and Torrentz Hydra Splatling.*
+
+King of Ham capped the zone first, but both teams traded the lead multiple times over the course of the game. PxG’s primary focus was keeping the Torrentz Hydra Splatling out of play as much as possible to reduce the long-range threat and Big Bubbler. King of Ham got to 1 point remaining before time was up, and PxG couldn’t knock out before the match closed. King of Ham took game one 99–91. 
+
+For game two, King of Ham banned Lemuria Hub and Shipshape Cargo Co. Going back to a map which they’d knocked out on earlier, PxG selected MakoMart. King of Ham traded one Splatling for a Clawz .96 Gal and the other swapped to a Nautilus 47\.
+
+Although PxG was able to take King of Ham down to their last player several times in the game, that didn’t stop King of Ham from taking points in strides, starting with stealing the lead from PxG early on. PxG didn’t have the same kind of painting power that King of Ham did, which led to King of Ham taking the victory by knockout. 
+
+For the second set in a row, game three went to Mincemeat Metalworks. King of Ham chose Flounder Heights and Bluefin Depot to strike, leading to PxG’s map selection.
+
+PxG ran with the lead, down to 14 by the halfway point in the game before being handed a hefty penalty. PxG inched closer to the knockout, but were stopped by a Heavy Splatling and its overwhelming paint output. In the last second of the game, King of Ham surpassed PxG’s lead, leaving no time for PxG to initiate overtime. The game ended 95–92 for King of Ham, giving them their first 3–0 of the event. 
+
+PxG, meanwhile, was left with their first 0–3 since facing EmpEror in the previous Global Gauntlet Finals. New Meta, however, won their set against mellow good, 3–2. All other Western teams went 1–3, except Healbook, who also had a 0–3 set. 
+
+### **Round 5 \- Milky Way vs. Always Here**
+
+Always Here had won all of their sets (aside from their first set against New Meta, which they forfeited) in a fairly dominant showing, at least 3–1. Milky Way had won their set against mellow good, but otherwise only had a record of six wins in 16 games. Always Here had been making their way through the West in lowest-to-highest seed order, and were on their last stop before seeds \#1 of both regions clashed.  
+
+Their game one had Milky Way banning Bluefin Depot and Barnacle & Dime, and Always Here striking Lemuria Hub and Inkblot Art Academy. The map chosen at random was Robo ROM-en, a map which Milky Way had axed in a previous round.
+
+Milky Way was at the advantage first, getting their zone timer to 40 while keeping Always Here’s player count down. Even when they lost the zone for the first time, they took it back quickly. Always Here just needed to break Milky Way’s formation once to set up their defense on the zone, and from there carried the game to a knockout at 2:33.
+
+Next, Always Here opted to strike Urchin Underpass and Humpback Pump Track. Milky Way selected Brinewater Springs to take their opponent to. 
+
+Within 10 seconds, Always Here secured the zone, and before the first minute was up, were locking Milky Way into their spawn. They were stopped at 16 by Milky Way’s Booyah Bomb, and went down in a delayed wipe. Always Here tried to lock out again, but went down three players twice, letting Milky Way rack up points. In the last 15 seconds, Always Here was wiped out. Milky Way won the game with a close 98–84. 
+
+<img width="1000" height="562" alt="R5_Mbrinewater" src="https://github.com/user-attachments/assets/ff436546-7f7c-4489-a11a-ca184b54c2f4" />
+
+*Each team is down to just their Charger player while the zone is neutral. Always Here’s .52 Gal throws a parting Ink Vac shot, which helps Always Here take the zone, stopping Milky Way at 2 ticks to KO.*
+
+The set now tied, Milky Way’s map strikes were Mincemeat Metalworks and Flounder Heights. Always Here selected MakoMart. 
+
+Milky Way took their points in one major leap, going from 100 to 20 in one minute. After losing the zone in a 2v2, Always Here closed the gap, stopped at 44 briefly before burning through their penalty and taking the lead. Milky Way’s Booyah Bomb took the zone from Always Here, left at 4 ticks. As the game neared its final minute, Milky Way once more grabbed the lead, leading into a knockout, putting them ahead in the set.
+
+Milky Way’s next map strikes were Eeltail Alley and Hammerhead Bridge. Always Here selected Um’ami Ruins as the map, hoping that the two zones would give them an edge and keep the set alive. 
+
+Another strong opening from Milky Way saw them take the zones and bring their lead all the way down to 13 by the halfway point, before Always Here got any points. As we saw before, all Always Here needed was one good opening into the zones to lock Milky Way out, and their opponent struggled to get back in. One Milky Way wipeout later, and Always Here knocked out to bring the set to a game five.
+
+<img width="1000" height="562" alt="R5_Aum&#39;ami" src="https://github.com/user-attachments/assets/c123be8d-51ad-46ff-b1f9-d597d37ac848" />
+
+*Streamer Sena gets a quad on Milky Way by the map’s elbow, keeping the zones secure long enough for Always Here to take the lead and go right to the victory.*
+
+Milky Way’s second game five—and the first one on stream—took place at Wahoo World after Always Here banned Crableg Capital and Manta Maria. 
+
+Like the other games, Milky Way’s opening brought them close to a knockout—this time to 19, before staggering respawns gave Always Here the opportunity to lock down the zone. Both teams went down two players in the last 30 seconds as Always Here took the lead. Milky Way brought the game into overtime, but an Ink Vac secured the 96–86 win for Always Here, giving them the 3–2 set win.
+
+There were no set wins for the West in Round 5, but Milky Way and Crickets both won two games, and PxG had one. While not the best round for Western wins, it was far from the worst, which was to come… 
+
+### **Round 6 \- Yamato Spirit vs. Rinascita**
+
+The final round of the Second Edition Global Gauntlet Finals streamed the set between Yamato Spirit, who had not been on stream yet, and Rinascita, who was on stream for the second time. Yamato Spirit had mixed results so far, winning 3–0 over Milky Way and Healbook, but losing 0–3 to PxG, and coming from a close 3–2 with Crickets. With a paint-focused comp, Yamato Spirit was looking to be a tough fight for Rinascita. 
+
+Game one’s map strikes from Yamato Spirit were MakoMart and Urchin Underpass. Rinascita’s strikes were Humpback Pump Track and Manta Maria. The match went to Inkblot Art Academy, where Yamato Spirit’s bold weapon picks—specifically from Azu—sparked many a comment between the casters, live chat, and players. 
+
+A daring Inkjet opening from Azu, who brought the Annaki Splattershot Nova, scattered Rinascita. Splash Walls set up by their ramp funneled Rinascita into predictable routes to get to the zone, giving Yamato Spirit the advantage while defending. In what would become a recurring theme, Yamato Spirit’s high painting output was too much for Rinascita, and Yamato Spirit knocked out at 3:41. 
+
+For game two, Yamato Spirit banned Lemuria Hub and Crableg Capital. Rinascita chose to take their opponent to Bluefin Depot, where they would be able to put up more of a fight with the moving zone and high verticality.
+
+<img width="1000" height="562" alt="R6_Ycomps" src="https://github.com/user-attachments/assets/1f7ff140-93fa-4c4e-b6f4-825e09901a68" />
+
+*Rinascita’s composition remained static throughout the set, but Yamato Spirit’s weapons all changed at least once, minus the Dynamo Roller. Azu changed weapons each game.*
+
+A double from Volty in the opening gave Rinascita their first points in the set, but the 9 points they gained weren’t enough to get the lead from Yamato Spirit. Yamato Spirit’s Dynamo Roller gave Rinascita the most trouble, equally in part to its paint spray and splatting power. This was the best game Rinascita had in the set, and Yamato Spirit still won by knockout before half of the game passed.
+
+The last map strikes from Yamato Spirit were for Mincemeat Metalworks and Shipshape Cargo Co. Yamato Spirit spawned in looking ready for Turf War with their Dynamo Roller, Custom Splattershot Jr., Order Splatling, and REEF-LUX 450\. 
+
+In the first minute, Rinascita scored one point. This was all they could get amid Yamato Spirit’s overwhelming paint. They had found Rinascita’s weak spot and were doing everything they could to exploit it. The game ended in less than two minutes, in a third and final knockout for Yamato Spirit. 
+
+Not just for Rinascita, but for the West as a collective, Round 6 was indisputably the roughest round between both Global Gauntlet Finals events. Every Western team lost 0–3, with the exception of PxG, who only won one game against Always Here. 
+
+<img width="1100" height="644" alt="GG2F_finalbracket" src="https://github.com/user-attachments/assets/96ab7ac4-8abe-4a44-98ab-238a0bee8cdf" />
+
+## **The Warm-Up for the Global Stage Concludes…**
+
+Compared to the First Edition Global Gauntlet Finals, more teams from the West won more sets; PxG and FTWin combined won three sets at the GG1 Finals, where this time around, PxG, New Meta, and Milky Way won five sets between themselves. On a single-game scale, the West also won two more games at the GG2 Finals (32) than during the GG1 Finals (30). 
+
+Counting New Meta’s default 3–0 when Always Here forfeited against them, the West won 35 individual games, five more than the previous event\!
+
+Unfortunately, not every Western team took home at least one win against Japan like last event—Healbook, despite some close games, went 0–3 each set. On the flip side, there weren’t any teams who won every single game like EmpEror had. CutieNK, who had the highest win rate from Japan, lost two games. Vacuum World, the runner-up, lost only three games total.
+
+In case you missed any events during the Global Gauntlets, you can check out IPL’s [Splat World Series: Global Gauntlet \#1](https://www.youtube.com/playlist?list=PLsJtNA8co7rbsx6QUnGvKuKptcbSGcROB) playlist on YouTube, which features their REWOUND series of videos, providing full commentary to the unstreamed matches from both Finals events\! 
+
+Now that the two Global Gauntlets have wrapped up, what’s next for the Splat World Series 2026 season?
+
+The summer will be full of events for teams from both Japan and the West to qualify for the Splat World Series 2026 main event in August. Eight teams per region will be sent to the SWS Finals, for a total of sixteen teams. 
+
+The first qualifier is the [Eastern Qualifier](https://sendou.ink/to/3373/info), exclusive to Japan. Originally, this event was set to take place on July 11th, but was [**rescheduled to Saturday, June 27th**](https://bsky.app/profile/iplabs.ink/post/3moejxusbr22p). It will still use the Eastern Timeslot of 4 AM PT / 7 AM ET / 1 PM CET / 8 PM JT. The Eastern Qualifier will be rebroadcast at 10 AM PT / 1 PM ET / 7 PM CET for Western audiences on the original date, July 11th. 
+
+The top four teams from the Eastern Qualifier will earn their spot on Japan’s roster for the SWS Finals. The other four teams representing Japan will be selected by AREA CUP. 
+
+There are two qualifiers for the West: one on [July 18th](https://sendou.ink/to/3374/info), and one on [July 25th](https://sendou.ink/to/3375/info). Both of these events will use the Western Timeslot, 10 AM PT / 1 PM ET / 7 PM CET / 2 AM JT. The top four teams from each Western Qualifier will advance to the Splat World Series 2026 Finals. 
+
+The final showdown takes place on August 7th and 8th, 2026, during the International Timeslot (8 PM PT / 11 PM ET **on Friday evening** / 5 AM CET / 12 PM JT **on Saturday afternoon**) on both days, for an event that begins on Friday evening and concludes on Sunday morning, for North American players—for European players, the event starts on Saturday morning and will finish mid-morning on Sunday. 
+
+Don’t let the release of Splatoon Raiders on July 23rd hoard all of the attention. The best Competitive Splatoon action that the world has to offer is around the corner\! 
+
+Original Posting Date: June 19, 2026 at [Splatoon Stronghold](https://www.splatoonstronghold.com/news/sws26-recap-gg2f).
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add article from Splatoon Stronghold; "SWS26 Recap Global Gauntlet 2 Finals", repost of https://www.splatoonstronghold.com/news/sws26-recap-gg2f