### PR TITLE
Stronghold Article "NA League 2026 Playoffs"

### DIFF
--- a/content/articles/na-league-2026-playoffs.md
+++ b/content/articles/na-league-2026-playoffs.md
@@ -1,0 +1,183 @@
+---
+title: "The Splatoon 3 North American League 2026 Playoffs RECAP"
+date: 2026-06-24
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+#### *After ten weeks of consecutive Competitive Splatoon Saturdays, who takes home a podium placement?* 
+
+<img width="1200" height="675" alt="nal-2026-playoffs-recap" src="https://github.com/user-attachments/assets/c7ad57ba-4214-47bd-a519-736c4bdfffb9" />
+
+On June 20th and 21st, 2026, the Splatoon 3 North American League 2026 reached its end, and the journey from the top to the finish line took place during two livestreams lasting a total of ten hours. Like last year’s NA League Playoffs, every single set was on stream, making sure each team had a chance to shine. 
+
+Zach, Cyren, and Nine commentated the Winner’s Quarterfinals on day 1\. Starting with Winner’s Semifinals, Zach, Mellana, and Falco rounded out day one, which ended after the Loser’s Top 8\. Day two began with Jordan, Mellana, and Falco for the Loser’s Quarterfinals; after Loser’s Semifinals, Nine and Cyren swapped out Mellana and Falco to conclude the Playoffs with Jordan. CzarDB was the spec cam operator both days. 
+
+The teams who made it to the Playoffs with the highest season standings during the Regular Season were: 
+
+1. Milky Way  
+2. Cream Soda  
+3. NME  
+4. Content Cat  
+5. Moonlight  
+6. Healbook  
+7. Duck Motif  
+8. SCUBA
+
+While watching replays of sets, keep in mind that a handful of sets did see the Splattercolor Screen. While only one set, Loser’s Top 8: Duck Motif vs. Healbook, had its effects on Nintendo’s official stream for a brief moment, take caution viewing replays from other players if you are sensitive to its effects. 
+
+## **Day 1**
+
+Day one consisted of Winner’s Quarterfinals, Winner’s Semifinals, and Loser’s Top 8\. Since every set was on stream, every team had the spotlight at least twice, before two teams were eliminated from the tournament before making it to day two. 
+
+### **Winner’s Quarterfinals Part 1: Milky Way vs. SCUBA (3–0)**
+
+Starting the event was the seed \#1 vs. seed \#8 match, Milky Way vs. SCUBA. The set would initiate a pattern of what the commentators would start to call the “trifecta” of modes: Splat Zones, Rainmaker, and Tower Control, all played one after the other. 
+
+SCUBA put up a fight against Milky Way; the final scores don’t tell the full story. Although Milky Way knocked out game one, Urchin Underpass Splat Zones, and game three, Manta Maria Tower Control, SCUBA didn’t go down without earning their fair share of points. In game two, they prevented the knockout at Scorch Gorge Rainmaker, but still lost 46–67, and were sent to the Loser’s Bracket. 
+
+### **Winner’s Quarterfinals Part 2: Content Cat vs. Moonlight (1–3)**
+
+The sets went from the furthest range in seeds right into seed \#4 vs. seed \#5, Content Cat vs. Moonlight. Just like in seeding, the games between these two were equally as close. Content Cat did make use of the Splattercolor Screen in this set, but CzarDB did a fantastic job avoiding its audio and visual disruption from being on stream. 
+
+The set started with Urchin Underpass again, but for Turf War, where Moonlight won by just 0.06%, 49.5%–48.9%. Undertow Spillway Rainmaker was just a hair away from a knockout for Content Cat, winning 99–80. In the last two games, Moonlight won both with points in the 90s: 98–75 (Museum d’Alfonsino Clam Blitz) and 97–63 (MakoMart Splat Zones). 
+
+### **Winner’s Quarterfinals Part 3: Cream Soda vs. Duck Motif (3–2)**
+
+The set between seed \#2 Cream Soda and seed \#7 Duck Motif was *the* set to spectate during round 1\. Many bracket predictions assumed Cream Soda would 3–0 Duck Motif, but Duck Motif showed up, with an L-3 Nozzlenose D in hand, to prove otherwise. 
+
+Cream Soda knocked out game one, Crableg Capital Splat Zones, but the start of the game was very rocky, nearly going to Duck Motif. Then Duck Motif took the next two wins: 70–59 at Robo ROM-en Tower Control, and 56.3%–40.4% at MakoMart Turf War. In a very close final two games, Cream Soda inched ahead, winning 52–50 after overtime at Inkblot Art Academy Clam Blitz, and 42–38 at Undertow Spillway Rainmaker. 
+
+### **Winner’s Quarterfinals Part 4: NME v. Healbook (3–0)**
+
+The last set of Winner’s Quarterfinals came down to seed \#3 NME vs. seed \#6 Healbook. These teams had come across each other once during the Regular Season, during week six, where NME won 3–1 in Winner’s Finals and went on to win the event against Content Cat. 
+
+Coming full circle to start the set with Urchin Underpass Splat Zones again, NME took the knockout, but from there would start to be slowed down by Healbook. Game two, Crableg Capital Tower Control, Healbook ran the game into overtime, but NME still came out 99–25. The set ended 70–42 at Museum d’Alfonsino Rainmaker, sending Healbook to the Loser’s Bracket. 
+
+### **Winner’s Semifinals Part 1: Milky Way vs. Moonlight (3–2)**
+
+Switching commentators to Zach, Mellana, and Falco, a repeat of last year’s League Playoffs Grand Finals was the highlight of Winner’s Semifinals. Last Playoffs, Moonlight went 1–3 twice against Milky Way, starting with Winner’s Semifinals, where Moonlight then won their way up the Loser’s Bracket to rematch Milky Way in Grand Finals.
+
+Mahi-Mahi Resort Splat Zones is classic map/mode between these two; although Moonlight made it to 3, Milky Way came up to knock out thanks to their ever-present Triple Inkstrikes. MakoMart Tower Control went to Milky Way as well, 84–45. Moonlight pushed the set to a game five after winning Museum d’Alfonsino Clam Blitz 53–30 and Urchin Underpass Rainmaker 53–52 after overtime. It came down to Scorch Gorge Turf War, where Milky Way won 64.3%–32.5%.
+
+### **Winner’s Semifinals Part 2: Cream Soda vs. NME (3–1)**
+
+On the other side of the Winner’s Semifinals, Cream Soda went up against NME. The teams met a few times during the Regular Season Top Cut, and while every time it was Cream Soda taking the win, NME has a record of taking multiple games from them. 
+
+For the third time, the set began with Urchin Underpass Splat Zones, with a knockout for Cream Soda. NME rebounded with their own KO at Inkblot Art Academy Tower Control. Scorch Gorge Rainmaker went into overtime, but Cream Soda won again, and they closed out the set with another knockout, at Mahi-Mahi Resort Clam Blitz. 
+
+### **Loser’s Top 8 Part 1: Content Cat vs. SCUBA (3–1)**
+
+Moving into the Loser’s Bracket now, Content Cat, SCUBA, Duck Motif, and Healbook would be determining the two teams who would be knocked out of the event before day two. Up first was Content Cat and SCUBA, who had been going head-to-head in the 2026 League as early as Regular Season Week 2\. Both teams had won and lost against the other, so there was no clear winner until the dust settled\!
+
+For the first time *not* at Urchin Underpass or Splat Zones, SCUBA took the first win, at MakoMart Turf War, 52.7%–44.5%. Content Cat got the next two wins as knockouts, at both Hagglefish Market Splat Zones and Undertow Spillway Rainmaker. The last game came down to overtime, where Content Cat won their third game in a row, 71–70. 
+
+### **Loser’s Top 8 Part 2: Duck Motif vs. Healbook (3–0)**
+
+The last set of day one was between Duck Motif and Healbook, bringing a five and a half hour stream to a close. Splattercolor Screen appeared in this set and its effects were on screen briefly, so if watching the stream replays, please take caution if you are sensitive to them. 
+
+Putting to bed Urchin Underpass and Splat Zones, the set instead started with Robo ROM-en Tower Control, which Duck Motif quite dominantly won 93–47. They moved to Shipshape Cargo Co. Turf War, which again went to Duck Motif, 59.2%–36.8%. Healbook couldn’t close out Museum d’Alfonsino Rainmaker, going 36–74, and instead it was Duck Motif advancing to Loser’s Quarterfinals for day two. 
+
+<img width="1000" height="562" alt="Playoffs_midpointbracket" src="https://github.com/user-attachments/assets/30065ddd-a90a-426e-9067-c52d23e78023" />
+
+
+## **Day 2**
+
+Day two would cover the latter half of the set, starting with Loser’s Quarterfinals and moving into Loser’s Semifinals, to Winner’s Finals, then Loser’s Finals, and last but not least, Grand Finals.
+
+### **Loser’s Quarterfinals Part 1: NME vs. Content Cat (3–0)**
+
+NME vs. Content Cat began day two, with Jordan, Mellana, and Falco starting the commentary block. Seeded \#3 and \#4, the set should have been close, but Content Cat had to contend with a team that had gotten to third place in the last North American League.  
+
+Mahi-Mahi Resort Splat Zones kicked off the day, and it was a knockout for NME. The next two games were decided by single-digit points, but NME took both for a 3–0 set: Shipshape Cargo Co. Tower Control (76–72) and Undertow Spillway Rainmaker (74–73). NME moved forward after the last 3–0 set of the Playoffs. 
+
+### **Loser’s Quarterfinals Part 2: Moonlight vs. Duck Motif (3–1)**
+
+Moonlight and Duck Motif, far from strangers with one another, especially since this was a repeat Loser’s Quarterfinals match from the last NA League. Vexen was replaced by Duck Motif’s coach, Atlas, for the first two games. 
+
+Moonlight won MakoMart Turf War by a wide margin; 66.1%–29.9%, and their streak bled into game two, Scorch Gorge Rainmaker, where they won 82–0. With Vexen returned, Duck Motif made a comeback with a knockout at Crableg Capital Splat Zones. Inkblot Art Academy Splat Zones was the closest game between the two, but it was Moonlight taking the 53–44 win and going on to meet NME in the next set. 
+
+### **Loser’s Semifinals: NME vs. Moonlight (3–1)**
+
+Another repeat from last year’s NA League, NME and Moonlight were once again pitted against another in the Playoffs. The set saw some interesting choices come out from Moonlight, namely in their choice of weapons, some of which the audience had never seen them use in tournament play until now. 
+
+<img width="1000" height="562" alt="LSF_TWmuseum" src="https://github.com/user-attachments/assets/201d3ef4-9b48-4189-8b38-2cba80dabf3f" />
+
+*The weapon choices from each team during Turf War at Museum d’Alfonsino. Of note is Moonlight (right), who brought out a Planetz Big Swig Roller and Glitterz L-3 Nozzlenose.*
+
+MakoMart was back as a set-starting map, for Tower Control, which Moonlight won, 68–30. NME won Museum d’Alfonsino Turf War 54.4%–43.7%, then Scorch Gorge Rainmaker 44–32. Shipshape Cargo Co. Clam Blitz went all the way into overtime: Moonlight opened the basket to make a push, but lost 49–56, taking 4th place in the 2026 Playoffs. 
+
+## **Winner’s Finals: Milky Way vs. Cream Soda (3–1)**
+
+Winner’s Finals saw one last commentator swap as Jordan remained on mic, joined by Nine and Cyren for the last three sets of the tournament. Milky Way and Cream Soda, seeds \#1 and \#2, would be a fresh fight for all viewers—these teams had never faced off in any of the Regular Season Top Cut events. 
+
+Of course, game one started with Splat Zones at Urchin Underpass. Milky Way had a tough time keeping Cream Soda away from the zone for two minutes; after warming up, they took the lead from their opponent for one minute. Cream Soda had the lead and points ticking down with less than two minutes to go, and went all the way to the knockout. 
+
+Tower Control at Inkblot Art Academy was a showdown between two teams who went undefeated in all Tower Control games during the Regular Season, and it was Milky Way retaining that record. Cream Soda brought the game into overtime, but could not surpass the lead that Milky Way gained in the first half, losing 43–67. 
+
+The rare Manta Maria Rainmaker pick came out, and the major points in the game were all defined by teams going down to their last player. Cream Soda got their checkpoint, then went down three players. Milky Way took the lead, then lost three players. Both times Cream Soda tried to build up momentum, losing three-quarters of their team prevented forward movement. Milky Way won their second game in a row, 71–37.
+
+We finally had an interesting game of Turf War\! …Just not for an exciting reason, rather one that caused some confusion. Cream Soda spent most of the game under the Danger\! warning. In the last 20 seconds, Thunder snuck into Milky Way’s base and started painting. In the last five seconds, the screen showed that Milky Way was the one now in Danger\!, and remained so until the end of the game. 
+
+So how did they win, 56.0%–40.5%?
+
+<img width="1000" height="562" alt="WF_TWmuseum" src="https://github.com/user-attachments/assets/7546d6b3-6738-4fbf-9fff-7ac23fae500e" />
+
+*The final second of Turf War at Museum d’Alfonsino. The visible area looks fairly even between Milky Way (blue) and Cream Soda (orange), but Milky Way has the Danger\! sign by their icons.*
+
+The Danger\! sign appears when a team is at least 10% behind their opponent in total ink coverage, and Milky Way won by 15.5%. No specials were fired off last-second to get them to have that much paint ahead of Cream Soda. This visual glitch also happened in Loser’s Finals, making it easier to detect a common variable as the cause. 
+
+In Loser’s Finals, the Danger\! sign popped up for NME (whose icons were on the left at the time), and in the same moment, the spectator cam switched to a player on the other team, shifting the sides that the teams were on in the overhead UI—NME moved from the left to the right. The Danger\! sign didn’t move with the teams, and instead showed that Cream Soda, who was now on the left, was incorrectly behind in points. 
+
+Once the spectator camera switched to back to NME, who was the actual team behind in ink coverage points, the Danger\! sign followed the correct team icons regardless of which side of the screen the team was on. The same thing happened in Winner’s Finals, only the game ended before we could see the spec cam change perspectives to see how the visual error fixed itself to correctly show that Cream Soda had less ink cover. 
+
+What a time to discover such a thing\! Hopefully this issue can be resolved in a future update.
+
+## **Loser’s Finals: Cream Soda vs. NME (3–1)**
+
+After Milky Way’s win in Winner’s Finals, Cream Soda was sent to face NME for the second time in the Playoffs. After having met in Winner’s Semifinals on day one, how have the teams changed strategies?
+
+The set started with Splat at Zones Undertow Spillway. NME was looking for a quick knockout, already at 11 ticks remaining with three minutes left in the game, but they were wiped out, letting Cream Soda retake the zones. NME was wiped out a second time, and by the time Cream Soda took the lead, they weren’t able to recover before Cream Soda knocked out. 
+
+<img width="1000" height="562" alt="LF_SZundertow" src="https://github.com/user-attachments/assets/54fec7a8-cf9f-4eb0-b736-5068ace47ad4" />
+
+*As Cream Soda threatened NME’s lead, a handful of jump-ins on the glass became easy targets for Gos and Thunder, leading to NME’s second wipeout.*
+
+On day one, NME KO’d at Inkblot Art Academy Tower Control, but on day two they were struggling to keep even half of their team up at the same time. They managed to stagger respawns enough to only be delayed wiped rather than fully wiped out for most of the game, but NME’s constant numbers disadvantage resulted in another Cream Soda win, 71–3. 
+
+Game three was Rainmaker at Mahi-Mahi Resort, and anyone who watched the Regular Season weeks knew what was coming: this was *the* map and mode combination for NME. Although they were wiped out right after running the Rainmaker to 67, afterward, Cream Soda was then caught in a delayed wipeout, letting NME clear their checkpoint, then go right to the knockout. The match lasted 57 seconds\! 
+
+Then the Museum d’Alfonsino Turf War game mentioned above took place—after the game restarted due to a disconnect. NME was in Danger\! starting 45 seconds in, and despite what the official stream might show, Cream Soda was never in Danger\!, as they were almost always ahead of their opponent. The final score was 57.8%–40.2%, to Cream Soda, sending them to Grand Finals, while NME took another NA League 3rd place medal. 
+
+## **Grand Finals: Milky Way vs. Cream Soda (3–1)**
+
+Cream Soda was back to staring down Milky Way. Both teams were championship material, with star-studded veterans. Who keeps what streaks once the storm settles? 
+
+No surprises: they started with Urchin Underpass Splat Zones. After two minutes had passed, Cream Soda was already at 27 ticks to win, with only a little bit of penalty points. Milky Way was in control of the zone, only at 87\. They got decently far, but Cream Soda pushed their lead again, to 9, before Milky Way had the zone back. Both teams went down two players, and Milky Way emerged, taking the knockout with them. 
+
+Then they went back to Turf War at Museum d’Alfonsino. Again, Cream Soda struggled heavily, finding themselves in the same shoes they put NME in during the last set, always down a few players and under the Danger\! warning. The score came out to 57.4%–37.6%, to Milky Way, again.
+
+Next was Tower Control, at MakoMart this time. Another close game; this time, Cream Soda had the early lead, but it was only to 49, low for this map. Milky Way pushed the tower to 52 and was stopped. The remaining three and a half minutes was Cream Soda on defense, stopping Milky Way at every push. It paid off; Cream Soda won 51–48. 
+
+<img width="1000" height="562" alt="GF_TCmakomart" src="https://github.com/user-attachments/assets/295aadd4-59ec-4325-9876-d163983a9192" />
+
+*Cream Soda’s first win in Grand Finals, at MakoMart Tower Control. This victory broke Milky Way’s undefeated Tower Control streak in the NA League at the very last possible moment\!*
+
+Game four went to Clam Blitz at Scorch Gorge; this was the last mode the teams had yet to play against one another. Milky Way opened the basket first… and then again, and again, taking their points to 52 across three pushes. At the last second, Big Bubbler set up, both teams down a player, Cream Soda scored their first points of the game. 
+
+Ten points away from tying with Milky Way, Cream Soda went down two players. Another clam in their basket. Another player down just as one respawned. The basket area cleared of allies, Cream Soda tried to jump in, only to be met with all four players of Milky Way blocking their path. 
+
+The basket closed, ending overtime with Cream Soda trailing behind 41–48. Milky Way took the Grand Finals set win, 3–1, just like Winner’s Finals against Cream Soda, and like Grand Finals against Moonlight during the 2025 NA League. 
+
+<img width="1000" height="562" alt="Playoffs_finalbracket" src="https://github.com/user-attachments/assets/ca582165-3747-4226-bdfa-a2e18b38a20a" />
+
+The Splatoon 3 North American League 2026 is now complete\! During the closing thoughts, both Cyren and Jordan alluded to a “next time”, hinting that the future may hold more League events for Splatoon 3\. Would it be another North American League? After two successful NA events, might Nintendo try for another regional League? 
+
+Just because the official Nintendo event is over, that doesn’t mean the heat turns down for Competitive Splatoon. The summer still has the Splat World Series on the horizon, and if that’s not enough, LANs across the world are aplenty\! 
+
+Make sure to be there and take part\! 
+
+Original Posting Date: June 24, 2026 at [Splatoon Stronghold](https://www.splatoonstronghold.com/news/the-splatoon-3-north-american-league-2026-playoffs).
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Article from Splatoon Stronghold; "The Splatoon 3 North American League 2026 Playoffs RECAP", repost of https://www.splatoonstronghold.com/news/the-splatoon-3-north-american-league-2026-playoffs