### PR TITLE
Stronghold Article "July + August 2026 LANs"

### DIFF
--- a/content/articles/july-august-2026-lans.md
+++ b/content/articles/july-august-2026-lans.md
@@ -1,0 +1,197 @@
+---
+title: "July + August 2026 LANs"
+date: 2026-07-04
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+#### *LANs across the globe come together to celebrate Splatoon 3 and the upcoming Splatoon Raiders game*
+
+<img width="1000" height="525" alt="July + August 2026 LANs" src="https://github.com/user-attachments/assets/24eb13fe-c434-4160-ba52-cd503cd84d7d" />
+
+Hot off the heels of the Splatoon 3 North American League and in the midst of the Splat World Series’ 2026 season, LANs continue to pop up across the globe. With folks having more free time in the summer, bigger LANs are opening up and taking as much space as they can before Splatoon Raiders drops on July 23rd and introduces launch party events to the usual rotation of locals.
+
+## **July 2026**
+
+### **United LAN 2026 \- July 1–5th, 2026 (Meschede, Germany)**
+
+United LAN (ULAN) is a six-day LAN in Germany that covers a handful of competitive Nintendo games, such as Splatoon, Pokemon Champions, and Mario Kart World. Registrants with overnight passes are able to sleep at the venue and are offered onsite breakfast.
+
+ULAN is BYOE: Bring Your Own Equipment\! Consoles, docks, controllers, games, monitors, and all charging devices and LAN cables are required to play in tournaments. Overnight attendees will need to bring sleeping gear as well, such as sleeping bags/air mattresses and bedding, eating utensils and dishes, and hygiene products—especially those who use the showering facilities.
+
+A packing list containing United LAN’s recommended essentials can be found on their website’s FAQ page: [https://united-lan.de/faq/](https://united-lan.de/faq/).
+
+United LAN 2026 begins on Wednesday, July 1st and closes on Monday, July 6th. The first five days are for gaming, and the final Monday is reserved for teardown and cleanup. The Splatoon 3 tournament is on Friday, July 4th. Celebrate ULAN’s nearly 20 years of LAN hosting\!
+
+### **VanCoral Summer 2026 \- July 4th, 2026 (Vancouver, Canada)**
+
+VanCoral, West Canada’s localhost LAN, is holding their summer edition at the University of British Columbia\! The venue, as always, is the UBC AMS Student Nest, which offers onsite food and drinks, and a handful of other amenities.
+
+The tournament is planned to be all four ranked modes, in a Round Robin into Single-Elimination bracket. To participate, you’ll need the game, and your Switch and controller. TOs recommend bringing headsets as well.
+
+VanCoral Summer 2026 starts at 3 PM. For more information, registration, and a Discord link, you can visit the event’s [Sendou.ink page](https://sendou.ink/to/3839/info).
+
+### **AVCon 2026 \- July 4–5th, 2026 (Wayville SA, Australia)**
+
+Over in Australia, the anime and gaming festival, [AVCon](https://www.avcon.org.au/), takes place over an extended weekend to celebrate all branches of pop culture. From Friday evening through Sunday, explore and experience competitive and casual gaming, cosplay contests, panels, food, and more\!
+
+The Splatoon 3 Anarchy Battle BYOD Tournament is on Saturday. It begins with Round Robin Turf War. The top 50% of teams advance to a Bo3 ranked-mode-only bracket, which will continue until two teams remain, where the finals will switch to Bo5. Switch 1 and 2s are permitted; regardless of console, players must bring all of their own equipment, with the exception of docks and monitors.
+
+There’s also a Salmon Run tournament\! Unlike the other event, all equipment will be provided for players, including Switch 2s. Teams will get one chance to bring in the highest egg count on a selected instance, and top producers will move on to a second, higher-hazard shift, where the winner will be determined.
+
+AVCon 2026 is located at the Adelaide Showground in Wayville SA 5034, Australia. The Splatoon 3 tournament starts at 3 PM on Saturday, July 4th, and the Salmon Run tournament runs from 1 PM to 2 PM on Sunday. Registration is done on [start.gg](https://www.start.gg/tournament/avcon-2026/details), but attendees must also purchase an AVCon ticket, which can be done at [https://events.humanitix.com/avcon-2026](https://events.humanitix.com/avcon-2026).
+
+### **Deep Sea DTX \- July 11th, 2026 (Texas, United States)**
+
+Texas Splatoon’s newest LAN, Deep Sea DTX, can be found at the University of Texas—anyone is welcome to join, whether you’re a student or not, or competitive player or spectator. With 74 attendees already registered at the time of writing, the event will be lively\!
+
+<img width="540" height="675" alt="DSDTX" src="https://github.com/user-attachments/assets/4e0f8977-25ce-4ee6-8eb6-ac8ca44a9a62" />
+
+*The design for Deep Sea DTX’s mascot, Princess Neptune, done by [@combotchi.bsky.social](https://bsky.app/profile/combotchi.bsky.social).*
+
+The 4v4 Splatoon 3 tournament comes with a pre-determined map list and its format will be Pools into split brackets. Participants need to bring their Switch and controller, game, and a headset. The matches will be livestreamed, and spectators can attend for free.
+
+Deep Sea DTX joins the roster of Splatoon LANs on Saturday, July 11th and can be found at the University of Texas at Dallas’s Comets LANding Gaming & Esports Center. For a parking map, Discord link, and other info, check out the event’s [start.gg](https://www.start.gg/tournament/deep-sea-dtx/details) page.
+
+### **Chi-Shoals \#44 \- July 11th, 2026 (Illinois, United States)**
+
+Illinois’ longstanding Splatoon LAN, Chi-Shoals, will take a break for a few months after its 44th edition, pausing for August and September before returning in October for \#45. You can still expect to find this LAN at the Harold Washington Library in Chicago, Illinois, and attend for free\!
+
+The main tournament will be a Groups to Single-Elimination format. To participate, please bring your Nintendo Switch, copy of Splatoon 3, headset, and a controller. The tournament will be streamed on the [SquidWest Twitch Channel](https://twitch.tv/squidwest)\!
+
+Chi-Shoals \#44 will start at 11 AM on Saturday, July 11th, 2026, and run until 4 PM CT. You can find more information on SquidWest’s [Challonge](https://challonge.com/communities/SquidWest) or [Sendou.ink page](https://sendou.ink/calendar/4601). Join the [SquidWest (Midwest Splatoon Players) Discord](https://discord.com/invite/Acv9qH6) server for further info and commentator opportunities\!
+
+### **Gridlock 2026 \- July 11–12th, 2026 (New York, United States)**
+
+One of the West’s yearly regionals, Gridlock, will be in the heart of New York for the first time\! Held at the OS NYC internet cafe in Bowery, NY—the same venue as Big Dapple—you can expect the same flair and fare that Metro Ink. brings to all of their events.
+
+<img width="584" height="675" alt="GridlockOfferings" src="https://github.com/user-attachments/assets/17addd7d-692f-4582-8397-89315236fe39" />
+
+*Metro Ink.’s Gridlock banner, along with a list of exciting happenings at this year’s event: $1000 starting prize pool, vendors & merch, karaoke, and… Bluefin Depot Splat Zones\!*
+
+Players participating can use a Switch 1 or Switch 2, but those using a Switch 2 must share their Switch 2 equipment with others if needed. Tabletop players are also accommodated, and will need to bring a USB-C to ethernet adapter. Controllers, game, console, and 3.5mm headset are also required.
+
+Gridlock 2026 takes place on Saturday and Sunday, July 11th–12th; doors open at 11 AM on both days. Commentary, volunteer, and art submission forms are available on Gridlock 2026’s [start.gg](https://www.start.gg/tournament/big-dapple-9/details) page, along with a link to the Discord server. The tournament will be streamed on the [GenGame Twitch Channel](https://www.twitch.tv/gengame)\!
+
+### **CALterna 07 \- July 18th, 2026 (California, United States)**
+
+Southern California’s local, CALterna, is back\! At B.Y.O. Games in Los Angeles, California, the 12-team-capped tournament expects to also host a Salmon Run side event. The tournament will also be for Splatoon 3, unlike last April’s CALterna event, CALternative, which brought out the Wii Us for a Splatoon (2015) LAN\!
+
+For the 4v4 tournament, players need to bring their Switch 1 or Switch 2 and docking station equipment. A controller and copy of Splatoon 3 are required, and a 3.5mm headset is recommended—a limited number of headsets are available onsite to borrow.
+
+CALterna 07 returns to SoCal on Saturday, July 18th, and the doors to B.Y.O. Games open at 1 PM. The tournament is planned to begin at 2 PM and the venue will be available until 9 PM\! Those wanting to watch at home can do so on [Twitch](https://twitch.tv/pickpickles).
+
+### **LAN of 10,000 Lakes \#3 \- July 18th, 2026 (Minnesota, United States)**
+
+With two successful runs behind them, LAN of 10,000 Lakes is cementing itself as a mainstay in the Twin Cities area of Minnesota. Found on the third floor of an office building, inside the RTM Gaming Lounge (wheelchair-accessible), the venue has a large projector screen and provides games on the side to play between sets\!
+
+Participants need to bring their own Switch and game, controller, and headset in order to play. Switch 2 owners can participate, but will need to bring their own Switch 2 dock and LAN cables. Those who bring their own Switch 1 dock and AC adapter and are willing to share it with others will get $2 off their registration fee.
+
+LAN of 10,000 Lakes \#3 kicks off on Saturday, July 18th, 2026, at the RunTheMix (RTM) Gaming Lounge in Roseville, Minnesota. RTM’s doors open at 12 PM, and the Swiss bracket starts at 1 PM. [Start.gg](https://www.start.gg/tournament/lan-of-10-000-lakes-3/details) has venue and entrance directions, tournament rules, Discord server invitation, and registration.
+
+### **Splatoon 3: Salmon Run Summit\! \- July 18th, 2026 (Michigan, United States)**
+
+Sharpen your Salmon Run skills ahead of Splatoon Raiders’ launch in Ann Arbor, Michigan, at the Salmon Run Summit\! Not just a warm up for the next entry in the Splatoon series, but also for the next MI LAN, the Hyper-Local Splatfest, taking place the following week.
+
+Team up with other attendees during the two-hour event in a casual event geared toward fun. No Switch? No problem\! There will be consoles to borrow at the library venue, ensuring anyone can play, even if they’ve never tried the game before.
+
+Splatoon 3: Salmon Sun Summit\! starts at 1 PM and runs until 3 PM in the Program Room at the Ann Arbor District Library Traverwood Branch in Michigan. Advance registration is not required; more details can be found on the AADL’s program page: [https://aadl.org/node/666648](https://aadl.org/node/666648). The event occurs on Saturday, July 18th.
+
+<img width="1200" height="675" alt="1200px-Raiders_Mechanic_and_Deep_Cut_promotional_screenshot" src="https://github.com/user-attachments/assets/675b9362-45f6-41ea-a276-feccdde2a34c" />
+
+*Splatoon Raiders releases on July 23rd, 2026\!*
+
+### **Splatoon 3: Hyper-Local Splatfest \- July 25th, 2026 (Michigan, United States)**
+
+Following the Salmon Run Summit\! taking place one week prior, Michigan’s Hyper-Local Splatfest comes back, this time at the Ann Arbor District Downtown Library instead of the Traverwood Branch. The event is open to guests of all ages and skill levels\!
+
+The tourney is planned to run from 1 PM to 4 PM ET. No need to worry about traveling with your own equipment: as the event page says, “We'll provide the gear in-game and out; you bring the skills for a chance to win a prize.”
+
+Splatoon 3: Hyper-Local Splatfest will be at the Ann Arbor District Downtown Library in the 4th floor Program Room from 1–4 PM on Saturday, July 25th. Registration is not required for this event. Further details can be found on the AADL’s website: [https://aadl.org/node/666381](https://aadl.org/node/666381).
+
+### **Splatoon Raiders Launch Party (Las Cruces) \- July 25th, 2026 (New Mexico, United States)**
+
+The Inklings of Las Cruces, known for the Desert Highlands local in New Mexico, are holding a Splatoon Raiders Launch Party two days after the release of the new game\! No advance registration needed. Show up to have fun with your peers and experience Splatoon Raiders, either solo or take advantage of local multiplayer options\!
+
+The Las Cruces Splatoon Raiders Launch Party will be at the same venue that Desert Highlands is at, Geek Shack in Las Cruces, New Mexico. Looking to see who else is attending on Saturday, June 25th, 2026? Join the [Inklings of Las Cruces Discord](https://discord.com/invite/zpAM3XrRFA)\!
+
+### **Splatoon Raiders Launch Party (Houston) \- July 25th, 2026 (Texas, United States)**
+
+One state over, Texas Splatoon is also having their own Splatoon Raiders Launch Party on the same day as Las Cruces\! Cooling down from their newest LAN, Deep Sea DTX, the launch party will be at H-Town Splashdown’s usual venue, Game Guys.
+
+Texas Splatoon promises more information will be released closer to the event’s date, July 25th, 2026\. Game Guys can be found inside of Almeda Mall in Houston, Texas. Keep up with the latest news drops by joining the [Texas Splatoon Discord](https://discord.com/invite/KmZmfv5jaX)\!
+
+### **Get On My Level (GOML) 2026 \- July 31–August 2nd, 2026 (Ontario, Canada)**
+
+Closing out July and ringing in August, Get On My Level (GOML) is Canada’s longest-running fighting game major; in addition to Splatoon, other titles featured include Super Smash Bros. Ultimate and Melee, Rivals of Aether I and II, Street Fighter 6, and Guilty Gear: Strive, among others. Outside of the game, there will be a 2v2 basketball tournament and after-party boat cruise\!
+
+<img width="1070" height="600" alt="GOMLboat" src="https://github.com/user-attachments/assets/efdbea4d-0ccb-441e-b5da-5437fa8026d8" />
+
+*The Get On My Boat 2026 \- After Party Boat Cruise crew rented out a pirate ship for registered attendees to set sail on\!*
+
+New in 2026, the Splatoon 3 tournament at GOML will support Switch 1 AND 2s; bring your console of choice, Nintendo-licensed controller, copy of the game, and 3.5mm headset. IDs are required for badge pickup, and players under 18 years old will also need to submit a consent form signed by a parent or guardian to get their badge.
+
+The consent form, along with tournament rules, registration, event schedule, and much more, can be found on GOML’s [start.gg](https://www.start.gg/tournament/get-on-my-level-2026-canadian-fighting-game-championships/details) page. For the map list, FAQs, carpooling, and other conversation/help, join the [Splat LANs Discord](https://discord.com/invite/25UGew5XVA) server. Not attending but still want to watch the matches? The Splatoon 3 tournament will be streamed on the [GenGame Twitch Channel](https://www.twitch.tv/gengame).
+
+Get On My Level (GOML) 2026 \- Canadian Fighting Game Championship will be held between Friday, July 31st and Sunday, August 2nd. Badge pickup opens at 5 PM on July 30th, and the venue doors open at 10:30 AM on Friday. Splatoon 3 will be on Saturday, August 1st starting at 12 PM, and wrap up on Sunday, starting at 11 AM.
+
+## **August 2026**
+
+### **Sunset Surge: 3-Year Anniversary \- August 1st, 2026 (Arizona, United States)**
+
+Sunset Surge celebrates three years of bringing together the Arizona Splatoon community\! Following Sunset Surge: Blossom Blitz last April, they’ve hit the double-digits with their LAN events.
+
+The main event is a 16-team-capped tournament with all four ranked modes. Tournament participants should bring their Switch 1 (Switch 2 is not permitted), dock and cables, controller, game, and 3.5mm headset. Handheld players will be accommodated; reach out to staff in the [Sunset Surge \- Arizona Splatoon Discord](https://discord.com/invite/xmcsyFPrKN) server so the team can bring the necessary equipment.
+
+Want to lend a hand? Take a look at the [start.gg](https://www.start.gg/tournament/sunset-surge-3-year-anniversary-arizona-splatoon-lan/details) page for commentary, volunteer, and art contest information\! You’ll also find map directions, tournament rules, a smorgasbord of art and photos from past events, and more reasons to attend\!
+
+Registration for Sunset Surge: 3-Year Anniversary ends on Saturday, July 25th—one week before the event. The LAN is on Saturday, August 1st, 2026, and the tournament will be streamed on [SplatoonTourney’s Twitch Channel](https://www.twitch.tv/splatoontourney). You can find Sunset Surge at the ASU Esports Arena on the 3rd Floor, Room \#315, in Tempe, Arizona.
+
+### **Splat Vibes Vol. 4 \- August 1–2nd, 2026 (Twickenham, UK)**
+
+Over in the United Kingdom, Splat Vibes’ yearly two-day Splatoon LAN at St. Mary’s University will be running across August 1st and 2nd\! Most of the team slots are already full; the LAN has a cap of 20 teams for the tournament. Not interested in ranked modes? Join as a spectator or Tableturf competitor\!
+
+The main event starts with Round Robin Groups on Saturday and concludes with a Top 8 Double-Elimination bracket on Sunday. The map list, along with rules, directions, and more, are available on [start.gg](https://www.start.gg/tournament/splat-vibes-vol-4/details). Participants need to bring their own console, controller, and game. Switch 2s will be accommodated, but players should bring their own dock and cables to ensure they have all of the necessary equipment to play.
+
+Registration for Splat Vibes Vol. 4, on August 1st and 2nd, 2026, closes on July 31st or when the 20-team cap is reached. Teambuilding and additional information can be found in the [UK Splatoon LANS Discord](https://discord.com/invite/2nTr33Kj74) server.
+
+### **Kentucky Fried Squids \#1 \- August 8th, 2026 (Kentucky, United States)**
+
+Kentucky Fried Squids, one of the newest LANs in the United States, has been cooking for months and is ready to serve\! Located inside the Owensboro Convention Center in Kentucky, the venue is spacious and provides an onsite option for food and beverages.
+
+The tournament format will be three rounds of Swiss into Single-Elimination Brackets. Those wanting to take part must bring their own equipment: Switch, dock, cables, controller, game, and 3.5mm headset. Switch 2s are permitted. Competition registration closes on August 6th, and spectating is free\!
+
+Kentucky Fried Squids \#1’s inaugural event opens its doors on Saturday, August 8th, 2026\! Check-in starts at 11 AM CT; registration can be done on [start.gg](https://www.start.gg/tournament/kentucky-fried-squids-1/details). Find other attendees to form a team with via the [Kentucky Fried Squids Discord](https://discord.com/invite/5ZKFf7FHmv) server.
+
+<img width="1068" height="600" alt="kfs8s" src="https://github.com/user-attachments/assets/2aa0963e-b47f-420b-a182-daa783b49270" />
+
+*Need to practice with your squad before showing up to throw down at the Kentucky Fried Squids LAN? Join the KFS Discord server and participate in the weekly Kentucky 8s\!*
+
+### **SeaBATTLE\! X — Xtreme Summer \- August 8th, 2026 (Washington, United States)**
+
+SeaBATTLE\! reaches double digits\! The tenth iteration of Seattle’s local returns to GameWorks, located downtown with nearby public transport options, and boasting an in-house kitchen to order fresh food and beverages to keep your cool with.
+
+Tournament participants need their Switch, controller, Splatoon 3, and 3.5mm headset. Switch 2s will be allowed, but users will need to bring their own Switch 2 dock and adapter, labeled, and select the appropriate console option when registering. OLEDs are also allowed. Up to 14 teams can register, and registration ends on August 3rd. Spectators are not limited, and can register online or at the venue.
+
+SeaBATTLE\! X — Xtreme Summer is hosted at the GameWorks video arcade in Seattle, Washington on Saturday, August 8th, 2026\. Check-in starts at 11 AM, and Wave A Pools start at 12 PM. More event information, including a Discord invitation and schedule, can be found on SeaBATTLE’s [start.gg](https://www.start.gg/tournament/seabattle-xtreme-summer/details) page.
+
+SplatoonTourney will be streaming this event on Twitch\!
+
+### **Booyah Bay: Redwood Riot \- August 15th, 2026 (California, United States)**
+
+San José, California’s premier Splatoon LAN is held at Guildhouse’s Great Hall, and will have event merchandise, both new and old, at the ready\! Three parking garages are nearby, allowing for venue and vehicle access throughout the event.
+
+Playing in the tournament requires a Nintendo Switch, controller, and up-to-date copy of Splatoon 3\. A 3.5mm headset and charging cables are also highly recommended. Switch 2s and Switch Lites will be supported, but Switch 2 users must bring their dock and adapters, and Switch Lite users must bring an ethernet adapter.
+
+The [Booyah Bay \- NorCal Local LAN Discord](https://discord.com/invite/BmRnAHv4gX) is available for anyone to join who needs equipment, accommodations, or teammates to play with.
+
+Booyah Bay: Redwood Riot has put a bounty on their reigning champions, due on Saturday, August 15th, 2026 at Guildhouse’s Great Hall\! Further bounty details and links can be found on Booyah Bay’s [start.gg](https://www.start.gg/tournament/booyah-bay-redwood-riot-splatoon-3-lan-san-jose-ca/details) page, and for those who want to watch at home, the event will be streamed live on [SplatoonTourney’s Twitch](https://www.twitch.tv/splatoontourney)\!
+
+The release of Splatoon Raiders has opened the door for LANs to mix up their events and make more space for Salmon Run enthusiasts. It’s too early to know for sure just how much Raiders will change the in-person Splatoon experience, but on the technical side, it does make a greater case for Switch 2 accommodations, as more and more players upgrade to the newer console for the Switch 2-exclusive title.
+
+As online tournaments continue to run strong, don’t count out major LAN events—they’re just starting to pick up, and only get bigger from here\! Keep up to date with LANs and find resources on attending using [Splatoon Stronghold’s LANs page](https://www.splatoonstronghold.com/lan-map).
+
+Original Posting Date: July 4, 2026 at [Splatoon Stronghold](https://www.splatoonstronghold.com/news/july-august-2026-lans).
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add article from Splatoon Stronghold; "July + August 2026 LANs", repost of https://www.splatoonstronghold.com/news/july-august-2026-lans