### PR TITLE
Fix tab button styles being overriden by /plans

### DIFF
--- a/app/components/elements/Tabs.module.css
+++ b/app/components/elements/Tabs.module.css
@@ -19,27 +19,27 @@
 	}
 }
 
-.tabButton {
-	background-color: transparent;
-	border: none;
-	font-size: var(--font-xs);
-	border-radius: 0;
-	border-bottom: 2px solid transparent;
-	color: var(--color-text-high);
-	white-space: nowrap;
-	flex: 1;
-	transform: none !important;
-
-	& img {
-		min-width: 16px;
-		min-height: 16px;
-		margin-inline-end: var(--s-1-5);
-	}
-}
-
 .tabContainer {
 	min-width: fit-content;
 	margin-bottom: -2px;
+
+	& .tabButton {
+		background-color: transparent;
+		border: none;
+		font-size: var(--font-xs);
+		border-radius: 0;
+		border-bottom: 2px solid transparent;
+		color: var(--color-text-high);
+		white-space: nowrap;
+		flex: 1;
+		transform: none !important;
+
+		& img {
+			min-width: 16px;
+			min-height: 16px;
+			margin-inline-end: var(--s-1-5);
+		}
+	}
 
 	&:focus-visible {
 		outline: var(--focus-ring);


### PR DESCRIPTION
When navigating to `/plans`, the route re-loads the `Button.module.css` file, moving it to the end of the document stylesheet array, which increases it's priority and overrides the tab buttons override styles until page reload.

<img width="438" height="132" alt="16-11-30-40-chrome" src="https://github.com/user-attachments/assets/fee23a23-bf39-4052-8ded-0cd085ab924a" />

Fixed by nesting the tab button styles which increases specificity, so it's override styles will always apply regardless of stylesheet order.