### PR TITLE
For CUSTOM Pick/Ban, fix & add new options

### DIFF
--- a/app/db/tables.ts
+++ b/app/db/tables.ts
@@ -749,6 +749,7 @@ export type WhoSide = (typeof WHO_SIDES)[number];
 export const ACTION_TYPES = [
 	"ROLL",
 	"PICK",
+	"PICK_NO_MODE_REPEAT",
 	"BAN",
 	"MODE_PICK",
 	"MODE_BAN",

--- a/app/db/tables.ts
+++ b/app/db/tables.ts
@@ -735,6 +735,8 @@ export interface TournamentRoundMaps {
 }
 
 export const WHO_SIDES = [
+	"RANDOM",
+	"RANDOM_OTHER",
 	"ALPHA",
 	"BRAVO",
 	"HIGHER_SEED",

--- a/app/features/tournament-bracket/components/CustomFlowBuilder.tsx
+++ b/app/features/tournament-bracket/components/CustomFlowBuilder.tsx
@@ -51,6 +51,8 @@ import {
 import styles from "./CustomFlowBuilder.module.css";
 
 const WHO_I18N_KEYS = {
+	RANDOM: "tournament:customFlow.who.RANDOM",
+	RANDOM_OTHER: "tournament:customFlow.who.RANDOM_OTHER",
 	ALPHA: "tournament:customFlow.who.ALPHA",
 	BRAVO: "tournament:customFlow.who.BRAVO",
 	HIGHER_SEED: "tournament:customFlow.who.HIGHER_SEED",

--- a/app/features/tournament-bracket/components/CustomFlowBuilder.tsx
+++ b/app/features/tournament-bracket/components/CustomFlowBuilder.tsx
@@ -64,6 +64,7 @@ const WHO_I18N_KEYS = {
 const ACTION_I18N_KEYS = {
 	ROLL: "tournament:customFlow.action.ROLL",
 	PICK: "tournament:customFlow.action.PICK",
+	PICK_NO_MODE_REPEAT: "tournament:customFlow.action.PICK_NO_MODE_REPEAT",
 	BAN: "tournament:customFlow.action.BAN",
 	MODE_PICK: "tournament:customFlow.action.MODE_PICK",
 	MODE_BAN: "tournament:customFlow.action.MODE_BAN",

--- a/app/features/tournament-bracket/core/PickBan.test.ts
+++ b/app/features/tournament-bracket/core/PickBan.test.ts
@@ -8,6 +8,7 @@ import {
 	mapsListWithLegality,
 	type PickBanEvent,
 	type PickBanTeam,
+	randomWhoTeamIndex,
 	resolveCurrentStep,
 	resolveTeamFromSide,
 	teamOfEvent,
@@ -413,6 +414,224 @@ describe("resolveTeamFromSide", () => {
 			}),
 		).toBe(100);
 	});
+
+	it("resolves RANDOM to the coin-flip team index", () => {
+		expect(
+			resolveTeamFromSide({
+				side: "RANDOM",
+				teams,
+				results: [],
+				randomTeamIndex: 0,
+			}),
+		).toBe(100);
+		expect(
+			resolveTeamFromSide({
+				side: "RANDOM",
+				teams,
+				results: [],
+				randomTeamIndex: 1,
+			}),
+		).toBe(200);
+	});
+
+	it("resolves RANDOM_OTHER to the complement of the coin flip", () => {
+		expect(
+			resolveTeamFromSide({
+				side: "RANDOM_OTHER",
+				teams,
+				results: [],
+				randomTeamIndex: 0,
+			}),
+		).toBe(200);
+		expect(
+			resolveTeamFromSide({
+				side: "RANDOM_OTHER",
+				teams,
+				results: [],
+				randomTeamIndex: 1,
+			}),
+		).toBe(100);
+	});
+
+	it("throws when RANDOM side is missing randomTeamIndex", () => {
+		expect(() =>
+			resolveTeamFromSide({ side: "RANDOM", teams, results: [] }),
+		).toThrow();
+	});
+});
+
+describe("randomWhoTeamIndex", () => {
+	it("is deterministic for the same match and draw group", () => {
+		const args = {
+			matchId: 42,
+			eventIndex: 0,
+			preSetLength: 3,
+			postGameLength: 2,
+		};
+
+		expect(randomWhoTeamIndex(args)).toBe(randomWhoTeamIndex(args));
+	});
+
+	it("returns 0 or 1", () => {
+		for (let matchId = 1; matchId <= 20; matchId++) {
+			const result = randomWhoTeamIndex({
+				matchId,
+				eventIndex: 0,
+				preSetLength: 3,
+				postGameLength: 2,
+			});
+			expect(result === 0 || result === 1).toBe(true);
+		}
+	});
+
+	it("shares a single flip across all pre-set steps", () => {
+		const base = { matchId: 7, preSetLength: 3, postGameLength: 2 };
+		const draw0 = randomWhoTeamIndex({ ...base, eventIndex: 0 });
+		const draw1 = randomWhoTeamIndex({ ...base, eventIndex: 1 });
+		const draw2 = randomWhoTeamIndex({ ...base, eventIndex: 2 });
+
+		expect(draw1).toBe(draw0);
+		expect(draw2).toBe(draw0);
+	});
+
+	it("shares a single flip within a post-game cycle but re-keys per map", () => {
+		const base = { matchId: 7, preSetLength: 3, postGameLength: 2 };
+		// cycle 0 => eventIndex 3, 4
+		const cycle0a = randomWhoTeamIndex({ ...base, eventIndex: 3 });
+		const cycle0b = randomWhoTeamIndex({ ...base, eventIndex: 4 });
+		// cycle 1 => eventIndex 5, 6
+		const cycle1a = randomWhoTeamIndex({ ...base, eventIndex: 5 });
+		const cycle1b = randomWhoTeamIndex({ ...base, eventIndex: 6 });
+
+		expect(cycle0b).toBe(cycle0a);
+		expect(cycle1b).toBe(cycle1a);
+	});
+
+	it("re-flips independently across maps (some match reflips)", () => {
+		const differs = Array.from({ length: 30 }, (_, i) => i + 1).some(
+			(matchId) => {
+				const base = { matchId, preSetLength: 0, postGameLength: 1 };
+				const map0 = randomWhoTeamIndex({ ...base, eventIndex: 0 });
+				const map1 = randomWhoTeamIndex({ ...base, eventIndex: 1 });
+				return map0 !== map1;
+			},
+		);
+
+		expect(differs).toBe(true);
+	});
+});
+
+describe("turnOf / teamOfEvent — RANDOM sides", () => {
+	const randomMaps: TournamentRoundMaps = {
+		count: 5,
+		type: "BEST_OF",
+		pickBan: "CUSTOM",
+		customFlow: {
+			preSet: [
+				{ action: "BAN", side: "RANDOM" },
+				{ action: "BAN", side: "RANDOM_OTHER" },
+				{ action: "PICK", side: "RANDOM" },
+			],
+			postGame: [{ action: "PICK", side: "WINNER" }],
+		},
+	};
+	const teams: [PickBanTeam, PickBanTeam] = [
+		{ id: 100, seed: 2 },
+		{ id: 200, seed: 1 },
+	];
+	const teamIds = [100, 200];
+
+	it("resolves RANDOM to one of the two teams", () => {
+		const result = turnOf({
+			matchId: 55,
+			results: [],
+			maps: randomMaps,
+			teams,
+			pickBanEventCount: 0,
+		});
+
+		expect(teamIds).toContain(result?.teamId);
+		expect(result?.action).toBe("BAN");
+	});
+
+	it("resolves RANDOM_OTHER to the complement of RANDOM within the same pre-set", () => {
+		const randomTurn = turnOf({
+			matchId: 55,
+			results: [],
+			maps: randomMaps,
+			teams,
+			pickBanEventCount: 0,
+		});
+		const randomOtherTurn = turnOf({
+			matchId: 55,
+			results: [],
+			maps: randomMaps,
+			teams,
+			pickBanEventCount: 1,
+		});
+
+		expect(randomOtherTurn?.teamId).not.toBe(randomTurn?.teamId);
+		expect(teamIds).toContain(randomOtherTurn?.teamId);
+	});
+
+	it("keeps RANDOM stable across steps sharing a draw group", () => {
+		const firstRandom = turnOf({
+			matchId: 55,
+			results: [],
+			maps: randomMaps,
+			teams,
+			pickBanEventCount: 0,
+		});
+		const secondRandom = turnOf({
+			matchId: 55,
+			results: [],
+			maps: randomMaps,
+			teams,
+			pickBanEventCount: 2,
+		});
+
+		expect(secondRandom?.teamId).toBe(firstRandom?.teamId);
+	});
+
+	it("is deterministic across repeated calls", () => {
+		const first = turnOf({
+			matchId: 55,
+			results: [],
+			maps: randomMaps,
+			teams,
+			pickBanEventCount: 0,
+		});
+		const second = turnOf({
+			matchId: 55,
+			results: [],
+			maps: randomMaps,
+			teams,
+			pickBanEventCount: 0,
+		});
+
+		expect(second).toEqual(first);
+	});
+
+	it("teamOfEvent agrees with the pending turnOf resolution for the same event", () => {
+		for (const eventIndex of [0, 1, 2]) {
+			const pending = turnOf({
+				matchId: 55,
+				results: [],
+				maps: randomMaps,
+				teams,
+				pickBanEventCount: eventIndex,
+			});
+			const recorded = teamOfEvent({
+				matchId: 55,
+				eventIndex,
+				maps: randomMaps,
+				teams,
+				results: [],
+			});
+
+			expect(recorded).toBe(pending?.teamId);
+		}
+	});
 });
 
 describe("turnOf — CUSTOM flow", () => {
@@ -439,6 +658,7 @@ describe("turnOf — CUSTOM flow", () => {
 
 	it("returns first preSet step", () => {
 		const result = turnOf({
+			matchId: 1,
 			results: [],
 			maps: customMaps,
 			teams,
@@ -455,6 +675,7 @@ describe("turnOf — CUSTOM flow", () => {
 
 	it("returns second preSet step", () => {
 		const result = turnOf({
+			matchId: 1,
 			results: [],
 			maps: customMaps,
 			teams,
@@ -471,6 +692,7 @@ describe("turnOf — CUSTOM flow", () => {
 
 	it("returns null when waiting for game result", () => {
 		const result = turnOf({
+			matchId: 1,
 			results: [],
 			maps: customMaps,
 			teams,
@@ -482,6 +704,7 @@ describe("turnOf — CUSTOM flow", () => {
 
 	it("returns postGame step after result", () => {
 		const result = turnOf({
+			matchId: 1,
 			results: [{ winnerTeamId: 200 }],
 			maps: customMaps,
 			teams,
@@ -508,6 +731,7 @@ describe("turnOf — CUSTOM flow", () => {
 		};
 
 		const result = turnOf({
+			matchId: 1,
 			results: [],
 			maps: rollMaps,
 			teams,
@@ -519,6 +743,7 @@ describe("turnOf — CUSTOM flow", () => {
 
 	it("returns null when set is over", () => {
 		const result = turnOf({
+			matchId: 1,
 			results: [
 				{ winnerTeamId: 200 },
 				{ winnerTeamId: 200 },
@@ -534,6 +759,7 @@ describe("turnOf — CUSTOM flow", () => {
 
 	it("returns null when no customFlow defined", () => {
 		const result = turnOf({
+			matchId: 1,
 			results: [],
 			maps: { count: 3, type: "BEST_OF", pickBan: "CUSTOM" },
 			teams,
@@ -567,15 +793,15 @@ describe("turnOf — CUSTOM flow stepCurrent/stepTotal", () => {
 		};
 
 		expect(
-			turnOf({ results: [], maps, teams, pickBanEventCount: 0 }),
+			turnOf({ matchId: 1, results: [], maps, teams, pickBanEventCount: 0 }),
 		).toMatchObject({ stepCurrent: 1, stepTotal: 2 });
 
 		expect(
-			turnOf({ results: [], maps, teams, pickBanEventCount: 1 }),
+			turnOf({ matchId: 1, results: [], maps, teams, pickBanEventCount: 1 }),
 		).toMatchObject({ stepCurrent: 2, stepTotal: 2 });
 
 		expect(
-			turnOf({ results: [], maps, teams, pickBanEventCount: 2 }),
+			turnOf({ matchId: 1, results: [], maps, teams, pickBanEventCount: 2 }),
 		).toMatchObject({ stepCurrent: 1, stepTotal: 1 });
 	});
 
@@ -596,6 +822,7 @@ describe("turnOf — CUSTOM flow stepCurrent/stepTotal", () => {
 
 		expect(
 			turnOf({
+				matchId: 1,
 				results: [{ winnerTeamId: 200 }],
 				maps,
 				teams,
@@ -605,6 +832,7 @@ describe("turnOf — CUSTOM flow stepCurrent/stepTotal", () => {
 
 		expect(
 			turnOf({
+				matchId: 1,
 				results: [{ winnerTeamId: 200 }],
 				maps,
 				teams,
@@ -614,6 +842,7 @@ describe("turnOf — CUSTOM flow stepCurrent/stepTotal", () => {
 
 		expect(
 			turnOf({
+				matchId: 1,
 				results: [{ winnerTeamId: 200 }],
 				maps,
 				teams,
@@ -638,11 +867,11 @@ describe("turnOf — CUSTOM flow stepCurrent/stepTotal", () => {
 		};
 
 		expect(
-			turnOf({ results: [], maps, teams, pickBanEventCount: 0 }),
+			turnOf({ matchId: 1, results: [], maps, teams, pickBanEventCount: 0 }),
 		).toMatchObject({ stepCurrent: 1, stepTotal: 1 });
 
 		expect(
-			turnOf({ results: [], maps, teams, pickBanEventCount: 1 }),
+			turnOf({ matchId: 1, results: [], maps, teams, pickBanEventCount: 1 }),
 		).toMatchObject({ stepCurrent: 1, stepTotal: 1 });
 	});
 
@@ -662,11 +891,11 @@ describe("turnOf — CUSTOM flow stepCurrent/stepTotal", () => {
 		};
 
 		expect(
-			turnOf({ results: [], maps, teams, pickBanEventCount: 0 }),
+			turnOf({ matchId: 1, results: [], maps, teams, pickBanEventCount: 0 }),
 		).toMatchObject({ stepCurrent: 1, stepTotal: 1 });
 
 		expect(
-			turnOf({ results: [], maps, teams, pickBanEventCount: 1 }),
+			turnOf({ matchId: 1, results: [], maps, teams, pickBanEventCount: 1 }),
 		).toMatchObject({ stepCurrent: 1, stepTotal: 1 });
 	});
 });
@@ -684,6 +913,7 @@ describe("turnOf — BAN_2 flow", () => {
 
 	it("returns action BAN for first picker", () => {
 		const result = turnOf({
+			matchId: 1,
 			results: [],
 			maps: ban2Maps,
 			teams,
@@ -708,6 +938,7 @@ describe("turnOf — BAN_2 flow", () => {
 
 	it("returns null when both teams have banned", () => {
 		const result = turnOf({
+			matchId: 1,
 			results: [],
 			maps: ban2Maps,
 			teams,
@@ -978,6 +1209,7 @@ describe("turnOf — COUNTERPICK flow", () => {
 
 	it("returns action PICK for loser of last game", () => {
 		const result = turnOf({
+			matchId: 1,
 			results: [{ winnerTeamId: 200 }],
 			maps: cpMaps,
 			teams,
@@ -996,6 +1228,7 @@ describe("turnOf — COUNTERPICK flow", () => {
 
 	it("returns null when match was completed without per-game results (drop-out)", () => {
 		const result = turnOf({
+			matchId: 1,
 			results: [],
 			maps: cpMaps,
 			teams,
@@ -1014,6 +1247,7 @@ describe("teamOfEvent", () => {
 
 	it("returns null when setup is not pick/ban", () => {
 		const result = teamOfEvent({
+			matchId: 1,
 			eventIndex: 0,
 			maps: { count: 3, type: "BEST_OF" },
 			teams,
@@ -1032,19 +1266,37 @@ describe("teamOfEvent", () => {
 
 		it("assigns event 0 to teams[1] (first picker)", () => {
 			expect(
-				teamOfEvent({ eventIndex: 0, maps: ban2Maps, teams, results: [] }),
+				teamOfEvent({
+					matchId: 1,
+					eventIndex: 0,
+					maps: ban2Maps,
+					teams,
+					results: [],
+				}),
 			).toBe(200);
 		});
 
 		it("assigns event 1 to teams[0] (second picker)", () => {
 			expect(
-				teamOfEvent({ eventIndex: 1, maps: ban2Maps, teams, results: [] }),
+				teamOfEvent({
+					matchId: 1,
+					eventIndex: 1,
+					maps: ban2Maps,
+					teams,
+					results: [],
+				}),
 			).toBe(100);
 		});
 
 		it("returns null for further indices", () => {
 			expect(
-				teamOfEvent({ eventIndex: 2, maps: ban2Maps, teams, results: [] }),
+				teamOfEvent({
+					matchId: 1,
+					eventIndex: 2,
+					maps: ban2Maps,
+					teams,
+					results: [],
+				}),
 			).toBeNull();
 		});
 	});
@@ -1058,6 +1310,7 @@ describe("teamOfEvent", () => {
 
 		it("attributes the counterpick to the loser of the preceding result", () => {
 			const result = teamOfEvent({
+				matchId: 1,
 				eventIndex: 0,
 				maps: cpMaps,
 				teams,
@@ -1069,6 +1322,7 @@ describe("teamOfEvent", () => {
 
 		it("also works for COUNTERPICK_MODE_REPEAT_OK", () => {
 			const result = teamOfEvent({
+				matchId: 1,
 				eventIndex: 1,
 				maps: { ...cpMaps, pickBan: "COUNTERPICK_MODE_REPEAT_OK" },
 				teams,
@@ -1080,6 +1334,7 @@ describe("teamOfEvent", () => {
 
 		it("returns null when no corresponding result exists", () => {
 			const result = teamOfEvent({
+				matchId: 1,
 				eventIndex: 0,
 				maps: cpMaps,
 				teams,
@@ -1109,18 +1364,31 @@ describe("teamOfEvent", () => {
 
 		it("resolves preSet steps via side (HIGHER_SEED → teams[1])", () => {
 			expect(
-				teamOfEvent({ eventIndex: 0, maps: customMaps, teams, results: [] }),
+				teamOfEvent({
+					matchId: 1,
+					eventIndex: 0,
+					maps: customMaps,
+					teams,
+					results: [],
+				}),
 			).toBe(200);
 		});
 
 		it("resolves preSet steps via side (LOWER_SEED → teams[0])", () => {
 			expect(
-				teamOfEvent({ eventIndex: 1, maps: customMaps, teams, results: [] }),
+				teamOfEvent({
+					matchId: 1,
+					eventIndex: 1,
+					maps: customMaps,
+					teams,
+					results: [],
+				}),
 			).toBe(100);
 		});
 
 		it("resolves postGame WINNER using the result of that cycle", () => {
 			const result = teamOfEvent({
+				matchId: 1,
 				eventIndex: 2,
 				maps: customMaps,
 				teams,
@@ -1132,6 +1400,7 @@ describe("teamOfEvent", () => {
 
 		it("resolves postGame LOSER using the result of that cycle", () => {
 			const result = teamOfEvent({
+				matchId: 1,
 				eventIndex: 3,
 				maps: customMaps,
 				teams,
@@ -1143,6 +1412,7 @@ describe("teamOfEvent", () => {
 
 		it("uses the correct cycle's result across multiple post-game cycles", () => {
 			const result = teamOfEvent({
+				matchId: 1,
 				eventIndex: 4,
 				maps: customMaps,
 				teams,
@@ -1154,6 +1424,7 @@ describe("teamOfEvent", () => {
 
 		it("returns null when customFlow is missing", () => {
 			const result = teamOfEvent({
+				matchId: 1,
 				eventIndex: 0,
 				maps: { count: 3, type: "BEST_OF", pickBan: "CUSTOM" },
 				teams,
@@ -1175,7 +1446,13 @@ describe("teamOfEvent", () => {
 			};
 
 			expect(
-				teamOfEvent({ eventIndex: 0, maps: rollMaps, teams, results: [] }),
+				teamOfEvent({
+					matchId: 1,
+					eventIndex: 0,
+					maps: rollMaps,
+					teams,
+					results: [],
+				}),
 			).toBeNull();
 		});
 	});
@@ -1189,6 +1466,7 @@ describe("currentTurnSessionStartedAt", () => {
 
 	it("returns null when there is no current turn", () => {
 		const result = currentTurnSessionStartedAt({
+			matchId: 1,
 			currentTurn: null,
 			events: [],
 			results: [],
@@ -1202,6 +1480,7 @@ describe("currentTurnSessionStartedAt", () => {
 
 	it("returns null when matchStartedAt is null", () => {
 		const result = currentTurnSessionStartedAt({
+			matchId: 1,
 			currentTurn: { teamId: 200, action: "BAN" },
 			events: [],
 			results: [],
@@ -1215,6 +1494,7 @@ describe("currentTurnSessionStartedAt", () => {
 
 	it("falls back to matchStartedAt when no events or results exist", () => {
 		const result = currentTurnSessionStartedAt({
+			matchId: 1,
 			currentTurn: { teamId: 200, action: "BAN" },
 			events: [],
 			results: [],
@@ -1228,6 +1508,7 @@ describe("currentTurnSessionStartedAt", () => {
 
 	it("BAN_2: second banner's session starts at the first ban's timestamp", () => {
 		const result = currentTurnSessionStartedAt({
+			matchId: 1,
 			currentTurn: { teamId: 100, action: "BAN" },
 			events: [{ createdAt: 1500 }],
 			results: [],
@@ -1241,6 +1522,7 @@ describe("currentTurnSessionStartedAt", () => {
 
 	it("COUNTERPICK: loser's session starts when the result is reported", () => {
 		const result = currentTurnSessionStartedAt({
+			matchId: 1,
 			currentTurn: { teamId: 200, action: "PICK" },
 			events: [],
 			results: [{ createdAt: 2000, winnerTeamId: 100 }],
@@ -1268,6 +1550,7 @@ describe("currentTurnSessionStartedAt", () => {
 		};
 
 		const result = currentTurnSessionStartedAt({
+			matchId: 1,
 			currentTurn: { teamId: 200, action: "BAN" },
 			events: [{ createdAt: 1500 }],
 			results: [],
@@ -1294,6 +1577,7 @@ describe("currentTurnSessionStartedAt", () => {
 		};
 
 		const result = currentTurnSessionStartedAt({
+			matchId: 1,
 			currentTurn: { teamId: 100, action: "BAN" },
 			events: [{ createdAt: 1100 }, { createdAt: 2500 }],
 			results: [{ createdAt: 2000, winnerTeamId: 200 }],

--- a/app/features/tournament-bracket/core/PickBan.test.ts
+++ b/app/features/tournament-bracket/core/PickBan.test.ts
@@ -1060,6 +1060,67 @@ describe("mapsListWithLegality — MODE_PICK restriction survives intervening ev
 	});
 });
 
+describe("mapsListWithLegality — pre-set MODE_PICK only restricts the first map", () => {
+	const SZ = "SZ" as ModeShort;
+	const TC = "TC" as ModeShort;
+	const RM = "RM" as ModeShort;
+
+	const toSetMapPool = [
+		{ mode: SZ, stageId: 1 as StageId },
+		{ mode: SZ, stageId: 2 as StageId },
+		{ mode: TC, stageId: 3 as StageId },
+		{ mode: TC, stageId: 4 as StageId },
+		{ mode: RM, stageId: 5 as StageId },
+	];
+
+	const teams = [{ mapPool: [] }, { mapPool: [] }] as unknown as Parameters<
+		typeof mapsListWithLegality
+	>[0]["teams"];
+
+	const customMaps: TournamentRoundMaps = {
+		count: 5,
+		type: "BEST_OF",
+		pickBan: "CUSTOM",
+		customFlow: {
+			preSet: [
+				{ action: "MODE_PICK", side: "HIGHER_SEED" },
+				{ action: "PICK", side: "LOWER_SEED" },
+			],
+			postGame: [{ action: "PICK", side: "LOSER" }],
+		},
+	};
+
+	it("does not lock the second map's mode to the pre-set MODE_PICK", () => {
+		// preSet: HIGHER_SEED picks mode SZ, LOWER_SEED picks SZ stage 1
+		// game 1: SZ stage 1 played, team 200 wins
+		// postGame cycle 1: LOSER (100) is now at PICK for game 2's map
+		const pickBanEvents: PickBanEvent[] = [
+			{ type: "MODE_PICK", stageId: null, mode: SZ },
+			{ type: "PICK", stageId: 1 as StageId, mode: SZ },
+		];
+
+		const result = mapsListWithLegality({
+			results: [{ mode: SZ, stageId: 1 as StageId, winnerTeamId: 200 }],
+			maps: customMaps,
+			mapList: null,
+			teams,
+			pickerTeamId: 100,
+			tieBreakerMapPool: [],
+			toSetMapPool,
+			pickBanEvents,
+		});
+
+		const legalModes = new Set(
+			result.filter((m) => m.isLegal).map((m) => m.mode),
+		);
+
+		// The pre-set MODE_PICK only decides the first map's mode; picking the
+		// second map should be free to choose any mode, not locked to SZ.
+		expect(legalModes.has(TC)).toBe(true);
+		expect(legalModes.has(RM)).toBe(true);
+	});
+});
+
 describe("mapsListWithLegality — pre-set MODE_BAN persists into postGame", () => {
 	const SZ = "SZ" as ModeShort;
 	const TC = "TC" as ModeShort;

--- a/app/features/tournament-bracket/core/PickBan.test.ts
+++ b/app/features/tournament-bracket/core/PickBan.test.ts
@@ -72,6 +72,37 @@ describe("validateCustomFlowSection", () => {
 		);
 	});
 
+	it("accepts PICK_NO_MODE_REPEAT as the last (map picking) step", () => {
+		const steps = [
+			{ action: "BAN" as const, side: "HIGHER_SEED" as const },
+			{ action: "PICK_NO_MODE_REPEAT" as const, side: "LOWER_SEED" as const },
+		];
+
+		expect(validateCustomFlowSection(steps, "postGame")).toEqual([]);
+	});
+
+	it("counts PICK_NO_MODE_REPEAT toward TOO_MANY_MAP_PICKS", () => {
+		const steps = [
+			{ action: "PICK" as const, side: "HIGHER_SEED" as const },
+			{ action: "PICK_NO_MODE_REPEAT" as const, side: "LOWER_SEED" as const },
+		];
+
+		expect(validateCustomFlowSection(steps, "preSet")).toContain(
+			CUSTOM_FLOW_VALIDATION_ERRORS.TOO_MANY_MAP_PICKS,
+		);
+	});
+
+	it("returns SAME_TEAM_MODE_AND_MAP_PICK for PICK_NO_MODE_REPEAT by the mode picker", () => {
+		const steps = [
+			{ action: "MODE_PICK" as const, side: "HIGHER_SEED" as const },
+			{ action: "PICK_NO_MODE_REPEAT" as const, side: "HIGHER_SEED" as const },
+		];
+
+		expect(validateCustomFlowSection(steps, "preSet")).toContain(
+			CUSTOM_FLOW_VALIDATION_ERRORS.SAME_TEAM_MODE_AND_MAP_PICK,
+		);
+	});
+
 	it("returns LAST_STEP_MUST_BE_PICK_OR_ROLL when last step is MODE_BAN", () => {
 		const steps = [{ action: "MODE_BAN" as const, side: "ALPHA" as const }];
 
@@ -1118,6 +1149,97 @@ describe("mapsListWithLegality — pre-set MODE_PICK only restricts the first ma
 		// second map should be free to choose any mode, not locked to SZ.
 		expect(legalModes.has(TC)).toBe(true);
 		expect(legalModes.has(RM)).toBe(true);
+	});
+});
+
+describe("mapsListWithLegality — PICK_NO_MODE_REPEAT", () => {
+	const SZ = "SZ" as ModeShort;
+	const TC = "TC" as ModeShort;
+	const RM = "RM" as ModeShort;
+
+	const toSetMapPool = [
+		{ mode: SZ, stageId: 1 as StageId },
+		{ mode: SZ, stageId: 2 as StageId },
+		{ mode: TC, stageId: 3 as StageId },
+		{ mode: TC, stageId: 4 as StageId },
+		{ mode: RM, stageId: 5 as StageId },
+	];
+
+	const teams = [{ mapPool: [] }, { mapPool: [] }] as unknown as Parameters<
+		typeof mapsListWithLegality
+	>[0]["teams"];
+
+	const customMaps: TournamentRoundMaps = {
+		count: 5,
+		type: "BEST_OF",
+		pickBan: "CUSTOM",
+		customFlow: {
+			preSet: [{ action: "PICK", side: "HIGHER_SEED" }],
+			postGame: [{ action: "PICK_NO_MODE_REPEAT", side: "LOSER" }],
+		},
+	};
+
+	it("excludes modes already played in the set", () => {
+		// game 1: SZ stage 1 played, now at PICK_NO_MODE_REPEAT for game 2's map
+		const pickBanEvents: PickBanEvent[] = [
+			{ type: "PICK", stageId: 1 as StageId, mode: SZ },
+		];
+
+		const result = mapsListWithLegality({
+			results: [{ mode: SZ, stageId: 1 as StageId, winnerTeamId: 200 }],
+			maps: customMaps,
+			mapList: null,
+			teams,
+			pickerTeamId: 100,
+			tieBreakerMapPool: [],
+			toSetMapPool,
+			pickBanEvents,
+		});
+
+		const legalModes = new Set(
+			result.filter((m) => m.isLegal).map((m) => m.mode),
+		);
+
+		// SZ was already played, so it must not be pickable again
+		expect(legalModes.has(SZ)).toBe(false);
+		expect(legalModes.has(TC)).toBe(true);
+		expect(legalModes.has(RM)).toBe(true);
+	});
+
+	it("falls back to allowing every mode once all modes have been played", () => {
+		// every mode has been played, but each still has an unplayed stage; a mode
+		// repeat is now unavoidable so the restriction lifts and the remaining
+		// stages of already-played modes become legal again
+		const pickBanEvents: PickBanEvent[] = [
+			{ type: "PICK", stageId: 1 as StageId, mode: SZ },
+			{ type: "PICK", stageId: 3 as StageId, mode: TC },
+			{ type: "PICK", stageId: 5 as StageId, mode: RM },
+		];
+
+		const result = mapsListWithLegality({
+			results: [
+				{ mode: SZ, stageId: 1 as StageId, winnerTeamId: 200 },
+				{ mode: TC, stageId: 3 as StageId, winnerTeamId: 100 },
+				{ mode: RM, stageId: 5 as StageId, winnerTeamId: 200 },
+			],
+			maps: customMaps,
+			mapList: null,
+			teams,
+			pickerTeamId: 100,
+			tieBreakerMapPool: [],
+			toSetMapPool,
+			pickBanEvents,
+		});
+
+		const legalMaps = result.filter((m) => m.isLegal);
+		const legalModes = new Set(legalMaps.map((m) => m.mode));
+
+		// SZ and TC each still have an unplayed stage (2 and 4); RM's only stage (5)
+		// was played. Modes are no longer restricted, only the played stages are.
+		expect(legalModes).toEqual(new Set([SZ, TC]));
+		expect(
+			legalMaps.some((m) => m.mode === SZ && m.stageId === (2 as StageId)),
+		).toBe(true);
 	});
 });
 

--- a/app/features/tournament-bracket/core/PickBan.ts
+++ b/app/features/tournament-bracket/core/PickBan.ts
@@ -715,7 +715,24 @@ function unavailableModes({
 			.filter((e) => e.type === "MODE_BAN" && e.mode !== null)
 			.map((e) => e.mode!);
 
-		return new Set([...preSetModeBans, ...currentSectionModeBans]);
+		const currentStep = maps.customFlow
+			? resolveCurrentStep({
+					eventCount: events.length,
+					preSet: maps.customFlow.preSet,
+					postGame: maps.customFlow.postGame,
+					resultsCount: results.length,
+				})
+			: null;
+		const noModeRepeatModes =
+			currentStep?.action === "PICK_NO_MODE_REPEAT"
+				? results.map((result) => result.mode)
+				: [];
+
+		return new Set([
+			...preSetModeBans,
+			...currentSectionModeBans,
+			...noModeRepeatModes,
+		]);
 	}
 
 	// COUNTERPICK: can't pick the same mode last won on
@@ -762,6 +779,12 @@ const BEFORE_SET_INVALID_WHO: ReadonlySet<WhoSide> = new Set([
 	"LOSER",
 ]);
 
+/** Actions where a team picks a map (as opposed to ROLL which has no picker). */
+const MAP_PICK_ACTIONS: ReadonlySet<ActionType> = new Set([
+	"PICK",
+	"PICK_NO_MODE_REPEAT",
+]);
+
 export const CUSTOM_FLOW_VALIDATION_ERRORS = {
 	STEP_MISSING_ACTION: "STEP_MISSING_ACTION",
 	STEP_MISSING_WHO: "STEP_MISSING_WHO",
@@ -800,8 +823,8 @@ export function validateCustomFlowSection(
 	if (
 		!lastStep ||
 		(lastStep.action &&
-			lastStep.action !== "PICK" &&
-			lastStep.action !== "ROLL")
+			lastStep.action !== "ROLL" &&
+			!MAP_PICK_ACTIONS.has(lastStep.action))
 	) {
 		errors.push(CUSTOM_FLOW_VALIDATION_ERRORS.LAST_STEP_MUST_BE_PICK_OR_ROLL);
 	}
@@ -821,14 +844,16 @@ export function validateCustomFlowSection(
 	}
 
 	const mapPickCount = steps.filter(
-		(s) => s.action === "PICK" || s.action === "ROLL",
+		(s) => s.action === "ROLL" || (s.action && MAP_PICK_ACTIONS.has(s.action)),
 	).length;
 	if (mapPickCount > 1) {
 		errors.push(CUSTOM_FLOW_VALIDATION_ERRORS.TOO_MANY_MAP_PICKS);
 	}
 
 	const modePickStep = steps.find((s) => s.action === "MODE_PICK");
-	const mapPickStep = steps.find((s) => s.action === "PICK");
+	const mapPickStep = steps.find(
+		(s) => s.action && MAP_PICK_ACTIONS.has(s.action),
+	);
 	if (
 		modePickStep?.side &&
 		mapPickStep?.side &&

--- a/app/features/tournament-bracket/core/PickBan.ts
+++ b/app/features/tournament-bracket/core/PickBan.ts
@@ -14,6 +14,7 @@ import type {
 import type { TournamentMapListMap } from "~/modules/tournament-map-list-generator/types";
 import invariant from "~/utils/invariant";
 import { logger } from "~/utils/logger";
+import { seededRandom } from "~/utils/random";
 import { assertUnreachable } from "~/utils/types";
 import type { TournamentDataTeam } from "./Tournament.server";
 
@@ -43,12 +44,14 @@ export function turnOf({
 	teams,
 	mapList,
 	pickBanEventCount,
+	matchId,
 }: {
 	results: Array<{ winnerTeamId: number }>;
 	maps: TournamentRoundMaps;
 	teams: [PickBanTeam, PickBanTeam];
 	mapList?: TournamentMapListMap[] | null;
 	pickBanEventCount?: number;
+	matchId: number;
 }): TurnOfResult | null {
 	if (!maps.pickBan) return null;
 
@@ -101,7 +104,7 @@ export function turnOf({
 			return { teamId: team.id, action: "PICK" };
 		}
 		case "CUSTOM": {
-			return turnOfCustom({ results, maps, teams, pickBanEventCount });
+			return turnOfCustom({ results, maps, teams, pickBanEventCount, matchId });
 		}
 		default: {
 			assertUnreachable(maps.pickBan);
@@ -114,11 +117,13 @@ function turnOfCustom({
 	maps,
 	teams,
 	pickBanEventCount,
+	matchId,
 }: {
 	results: Array<{ winnerTeamId: number }>;
 	maps: TournamentRoundMaps;
 	teams: [PickBanTeam, PickBanTeam];
 	pickBanEventCount?: number;
+	matchId: number;
 }): TurnOfResult | null {
 	if (
 		isSetOverByResults({ count: maps.count, results, countType: maps.type })
@@ -148,6 +153,12 @@ function turnOfCustom({
 		side: step.side!,
 		teams,
 		results,
+		randomTeamIndex: randomWhoTeamIndex({
+			matchId,
+			eventIndex: eventCount,
+			preSetLength: preSet.length,
+			postGameLength: postGame.length,
+		}),
 	});
 
 	const consecutiveInfo = resolveConsecutiveStepInfo({
@@ -282,12 +293,28 @@ export function resolveTeamFromSide({
 	side,
 	teams,
 	results,
+	randomTeamIndex,
 }: {
 	side: WhoSide;
 	teams: [PickBanTeam, PickBanTeam];
 	results: Array<{ winnerTeamId: number }>;
+	/**
+	 * The team index (0 or 1) the per-map coin flip landed on. Required when
+	 * `side` is RANDOM or RANDOM_OTHER. Compute with {@link randomWhoTeamIndex}.
+	 */
+	randomTeamIndex?: 0 | 1;
 }): number {
 	switch (side) {
+		case "RANDOM":
+		case "RANDOM_OTHER": {
+			invariant(
+				randomTeamIndex !== undefined,
+				"resolveTeamFromSide: randomTeamIndex required for RANDOM sides",
+			);
+			const teamIndex =
+				side === "RANDOM" ? randomTeamIndex : 1 - randomTeamIndex;
+			return teams[teamIndex].id;
+		}
 		case "ALPHA":
 			return teams[0].id;
 		case "BRAVO":
@@ -312,6 +339,32 @@ export function resolveTeamFromSide({
 }
 
 /**
+ * Resolves which of the two teams (0 or 1) the "RANDOM" side maps to for the
+ * given event via a deterministic per-map coin flip. A single flip covers one
+ * decision group: all pre-set steps share one flip, and each post-game cycle
+ * (one per map) has its own. "RANDOM_OTHER" is the complement of this index.
+ */
+export function randomWhoTeamIndex({
+	matchId,
+	eventIndex,
+	preSetLength,
+	postGameLength,
+}: {
+	matchId: number;
+	eventIndex: number;
+	preSetLength: number;
+	postGameLength: number;
+}): 0 | 1 {
+	const drawKey =
+		eventIndex < preSetLength
+			? "pre"
+			: `post-${postGameCycleIndex({ eventIndex, preSetLength, postGameLength })}`;
+
+	const { randomInteger } = seededRandom(`random-who-${matchId}-${drawKey}`);
+	return randomInteger(2) as 0 | 1;
+}
+
+/**
  * Resolves which team is responsible for the pick/ban event at a given index,
  * across all pick/ban variants (BAN_2, COUNTERPICK, COUNTERPICK_MODE_REPEAT_OK,
  * CUSTOM). Returns null when the setup is not pick/ban or the team cannot be
@@ -322,11 +375,13 @@ export function teamOfEvent({
 	maps,
 	teams,
 	results,
+	matchId,
 }: {
 	eventIndex: number;
 	maps: TournamentRoundMaps;
 	teams: [PickBanTeam, PickBanTeam];
 	results: Array<{ winnerTeamId: number }>;
+	matchId: number;
 }): number | null {
 	if (!maps.pickBan) return null;
 
@@ -374,7 +429,17 @@ export function teamOfEvent({
 				});
 			}
 
-			return resolveTeamFromSide({ side: step.side, teams, results });
+			return resolveTeamFromSide({
+				side: step.side,
+				teams,
+				results,
+				randomTeamIndex: randomWhoTeamIndex({
+					matchId,
+					eventIndex,
+					preSetLength: preSet.length,
+					postGameLength: postGame.length,
+				}),
+			});
 		}
 		default: {
 			assertUnreachable(maps.pickBan);
@@ -403,6 +468,7 @@ export function currentTurnSessionStartedAt({
 	matchStartedAt,
 	maps,
 	teams,
+	matchId,
 }: {
 	currentTurn: TurnOfResult | null;
 	events: Array<{ createdAt: number }>;
@@ -410,6 +476,7 @@ export function currentTurnSessionStartedAt({
 	matchStartedAt: number | null;
 	maps: TournamentRoundMaps;
 	teams: [PickBanTeam, PickBanTeam];
+	matchId: number;
 }): number | null {
 	if (!currentTurn || matchStartedAt == null) return null;
 
@@ -430,6 +497,7 @@ export function currentTurnSessionStartedAt({
 				maps,
 				teams,
 				results,
+				matchId,
 			});
 			if (teamMadeIt === currentTurn.teamId) continue;
 		}

--- a/app/features/tournament-bracket/core/PickBan.ts
+++ b/app/features/tournament-bracket/core/PickBan.ts
@@ -739,7 +739,7 @@ function currentSectionPickBanEvents({
 	const preSetLength = maps.customFlow?.preSet.length ?? 0;
 	const postGameLength = maps.customFlow?.postGame.length ?? 0;
 
-	if (pickBanEvents.length <= preSetLength) {
+	if (pickBanEvents.length < preSetLength) {
 		return pickBanEvents;
 	}
 

--- a/app/features/tournament-match/actions/to.$id.matches.$mid.server.ts
+++ b/app/features/tournament-match/actions/to.$id.matches.$mid.server.ts
@@ -583,7 +583,13 @@ export const action: ActionFunction = async ({ params, request }) => {
 			}
 
 			const eventType = (() => {
-				if (match.roundMaps.pickBan === "CUSTOM") return actionType;
+				if (match.roundMaps.pickBan === "CUSTOM") {
+					// a no-mode-repeat pick is stored as a regular map pick; the
+					// restriction only applies while choosing, not to the stored event
+					return actionType === "PICK_NO_MODE_REPEAT"
+						? ("PICK" as const)
+						: actionType;
+				}
 				if (match.roundMaps.pickBan === "BAN_2") return "BAN" as const;
 				return "PICK" as const;
 			})();

--- a/app/features/tournament-match/actions/to.$id.matches.$mid.server.ts
+++ b/app/features/tournament-match/actions/to.$id.matches.$mid.server.ts
@@ -517,6 +517,7 @@ export const action: ActionFunction = async ({ params, request }) => {
 				],
 				mapList,
 				pickBanEventCount: currentPickBanEvents.length,
+				matchId: match.id,
 			});
 			errorToastIfFalsy(turnOfResult, "Not time to pick/ban");
 			const pickerTeamId = turnOfResult.teamId;

--- a/app/features/tournament-match/components/TournamentMatchActionPickBanTab.tsx
+++ b/app/features/tournament-match/components/TournamentMatchActionPickBanTab.tsx
@@ -52,7 +52,9 @@ export function TournamentMatchActionPickBanTab({
 	const isCustomStageBan =
 		data.match.roundMaps?.pickBan === "CUSTOM" && turnOfResult.action === "BAN";
 	const sharedActionType: "PICK" | "BAN" =
-		turnOfResult.action === "PICK" || turnOfResult.action === "MODE_PICK"
+		turnOfResult.action === "PICK" ||
+		turnOfResult.action === "PICK_NO_MODE_REPEAT" ||
+		turnOfResult.action === "MODE_PICK"
 			? "PICK"
 			: "BAN";
 
@@ -142,7 +144,9 @@ function buildPickBanOptions({
 			seen.add(mode);
 			uniqueModes.push({ mode });
 		}
-		return uniqueModes;
+		return uniqueModes.sort(
+			(a, b) => modesShort.indexOf(a.mode!) - modesShort.indexOf(b.mode!),
+		);
 	}
 
 	if (isCustomStageBan) {

--- a/app/features/tournament-match/components/TournamentMatchBanner.tsx
+++ b/app/features/tournament-match/components/TournamentMatchBanner.tsx
@@ -492,6 +492,7 @@ function resolvePickBanBanner(
 		if (isCounterpick) return t("tournament:pickBan.counterpick");
 		switch (turnOfResult.action) {
 			case "PICK":
+			case "PICK_NO_MODE_REPEAT":
 				return t("tournament:pickBan.pickMap") + stepCounter;
 			case "BAN":
 				return t("tournament:pickBan.banMap") + stepCounter;

--- a/app/features/tournament-match/components/TournamentMatchBanner.tsx
+++ b/app/features/tournament-match/components/TournamentMatchBanner.tsx
@@ -430,6 +430,7 @@ function resolveCurrentSessionStartedAt({
 		teams,
 		mapList: data.mapList,
 		pickBanEventCount: data.pickBanEventCount,
+		matchId: data.match.id,
 	});
 	if (!currentTurn) return lastGameStartedAt;
 
@@ -441,6 +442,7 @@ function resolveCurrentSessionStartedAt({
 			matchStartedAt: data.match.startedAt,
 			maps: data.match.roundMaps,
 			teams,
+			matchId: data.match.id,
 		}) ?? lastGameStartedAt
 	);
 }
@@ -470,6 +472,7 @@ function resolvePickBanBanner(
 		],
 		mapList: data.mapList,
 		pickBanEventCount: data.pickBanEventCount,
+		matchId: data.match.id,
 	});
 	if (!turnOfResult) return null;
 

--- a/app/features/tournament-match/components/TournamentMatchTabs.tsx
+++ b/app/features/tournament-match/components/TournamentMatchTabs.tsx
@@ -235,6 +235,7 @@ function resolveTimelinePickBanData(
 			maps,
 			teams: pickBanTeamsLite,
 			results: data.results,
+			matchId: data.match.id,
 		});
 		if (teamId === null) continue;
 

--- a/app/features/tournament-match/match-page-context.tsx
+++ b/app/features/tournament-match/match-page-context.tsx
@@ -87,6 +87,7 @@ export function MatchPageProvider({
 					],
 					mapList: data.mapList,
 					pickBanEventCount: data.pickBanEventCount,
+					matchId: data.match.id,
 				})
 			: null;
 	const isPickBanStep =

--- a/locales/da/tournament.json
+++ b/locales/da/tournament.json
@@ -261,6 +261,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/da/tournament.json
+++ b/locales/da/tournament.json
@@ -251,6 +251,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/de/tournament.json
+++ b/locales/de/tournament.json
@@ -261,6 +261,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/de/tournament.json
+++ b/locales/de/tournament.json
@@ -251,6 +251,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/en/tournament.json
+++ b/locales/en/tournament.json
@@ -251,6 +251,8 @@
 	"customFlow.validation.tooManyModePicks": "At most one Mode Pick per section",
 	"customFlow.validation.tooManyMapPicks": "At most one Pick or Roll per section",
 	"customFlow.validation.sameTeamModeAndMapPick": "Same team cannot pick both mode and map",
+	"customFlow.who.RANDOM": "Random",
+	"customFlow.who.RANDOM_OTHER": "Random (other)",
 	"customFlow.who.ALPHA": "Team Alpha",
 	"customFlow.who.BRAVO": "Team Bravo",
 	"customFlow.who.HIGHER_SEED": "Higher Seed",

--- a/locales/en/tournament.json
+++ b/locales/en/tournament.json
@@ -261,6 +261,7 @@
 	"customFlow.who.LOSER": "Loser",
 	"customFlow.action.ROLL": "Random legal map",
 	"customFlow.action.PICK": "Pick (map)",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "Pick (map - no mode repeat)",
 	"customFlow.action.BAN": "Ban (map)",
 	"customFlow.action.MODE_PICK": "Pick (mode)",
 	"customFlow.action.MODE_BAN": "Ban (mode)",

--- a/locales/es-ES/tournament.json
+++ b/locales/es-ES/tournament.json
@@ -263,6 +263,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/es-ES/tournament.json
+++ b/locales/es-ES/tournament.json
@@ -253,6 +253,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/es-US/tournament.json
+++ b/locales/es-US/tournament.json
@@ -263,6 +263,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/es-US/tournament.json
+++ b/locales/es-US/tournament.json
@@ -253,6 +253,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/fr-CA/tournament.json
+++ b/locales/fr-CA/tournament.json
@@ -263,6 +263,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/fr-CA/tournament.json
+++ b/locales/fr-CA/tournament.json
@@ -253,6 +253,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/fr-EU/tournament.json
+++ b/locales/fr-EU/tournament.json
@@ -263,6 +263,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/fr-EU/tournament.json
+++ b/locales/fr-EU/tournament.json
@@ -253,6 +253,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/he/tournament.json
+++ b/locales/he/tournament.json
@@ -263,6 +263,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/he/tournament.json
+++ b/locales/he/tournament.json
@@ -253,6 +253,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/it/tournament.json
+++ b/locales/it/tournament.json
@@ -263,6 +263,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/it/tournament.json
+++ b/locales/it/tournament.json
@@ -253,6 +253,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/ja/tournament.json
+++ b/locales/ja/tournament.json
@@ -247,6 +247,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/ja/tournament.json
+++ b/locales/ja/tournament.json
@@ -257,6 +257,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/ko/tournament.json
+++ b/locales/ko/tournament.json
@@ -247,6 +247,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/ko/tournament.json
+++ b/locales/ko/tournament.json
@@ -257,6 +257,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/nl/tournament.json
+++ b/locales/nl/tournament.json
@@ -261,6 +261,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/nl/tournament.json
+++ b/locales/nl/tournament.json
@@ -251,6 +251,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/pl/tournament.json
+++ b/locales/pl/tournament.json
@@ -265,6 +265,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/pl/tournament.json
+++ b/locales/pl/tournament.json
@@ -255,6 +255,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/pt-BR/tournament.json
+++ b/locales/pt-BR/tournament.json
@@ -263,6 +263,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/pt-BR/tournament.json
+++ b/locales/pt-BR/tournament.json
@@ -253,6 +253,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/ru/tournament.json
+++ b/locales/ru/tournament.json
@@ -265,6 +265,7 @@
 	"customFlow.who.LOSER": "",
 	"customFlow.action.ROLL": "",
 	"customFlow.action.PICK": "",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "",
 	"customFlow.action.MODE_PICK": "",
 	"customFlow.action.MODE_BAN": "",

--- a/locales/ru/tournament.json
+++ b/locales/ru/tournament.json
@@ -255,6 +255,8 @@
 	"customFlow.validation.tooManyModePicks": "",
 	"customFlow.validation.tooManyMapPicks": "",
 	"customFlow.validation.sameTeamModeAndMapPick": "",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "",
 	"customFlow.who.BRAVO": "",
 	"customFlow.who.HIGHER_SEED": "",

--- a/locales/zh/tournament.json
+++ b/locales/zh/tournament.json
@@ -259,6 +259,7 @@
 	"customFlow.who.LOSER": "败者",
 	"customFlow.action.ROLL": "随机可用场地",
 	"customFlow.action.PICK": "选择（场地）",
+	"customFlow.action.PICK_NO_MODE_REPEAT": "",
 	"customFlow.action.BAN": "禁用（场地）",
 	"customFlow.action.MODE_PICK": "选择（模式）",
 	"customFlow.action.MODE_BAN": "禁用（模式）",

--- a/locales/zh/tournament.json
+++ b/locales/zh/tournament.json
@@ -249,6 +249,8 @@
 	"customFlow.validation.tooManyModePicks": "每个区块最多只能有一个“选择模式”",
 	"customFlow.validation.tooManyMapPicks": "每个区块最多只能有一个“选择场地”或“随机场地”",
 	"customFlow.validation.sameTeamModeAndMapPick": "同一支队伍不能同时选择模式和场地",
+	"customFlow.who.RANDOM": "",
+	"customFlow.who.RANDOM_OTHER": "",
 	"customFlow.who.ALPHA": "Alpha 队",
 	"customFlow.who.BRAVO": "Bravo 队",
 	"customFlow.who.HIGHER_SEED": "高顺位种子",


### PR DESCRIPTION
Now possible:

```
1) Coinflip: Winner picks mode
2) Loser picks map
3) Winner of game picks mode
4) Loser of game picks map
5) Maps and modes cannot be replayed within the same set
```

also, fixed a bug where pre-set mode pick applies for the team in the next map as well (off by one bug)