### PR TITLE
Fix scrollbar styles

### DIFF
--- a/app/styles/utils.css
+++ b/app/styles/utils.css
@@ -397,27 +397,31 @@
 
 	.scrollbar,
 	textarea {
-		@supports not selector(::-webkit-scrollbar) {
+		/* Firefox, Chrome 121+, Safari 18.2+ */
+		@supports (scrollbar-color: auto) {
 			scrollbar-width: thin;
 			scrollbar-color: var(--color-bg-higher) transparent;
 		}
 
-		&::-webkit-scrollbar,
-		&::-webkit-scrollbar-track {
-			background-color: transparent;
-			height: 14px;
-			width: 14px;
-		}
+		/* Legacy */
+		@supports not (scrollbar-color: auto) {
+			&::-webkit-scrollbar,
+			&::-webkit-scrollbar-track {
+				background-color: transparent;
+				height: 14px;
+				width: 14px;
+			}
 
-		&::-webkit-scrollbar-thumb {
-			background-color: var(--color-base-4);
-			border-radius: var(--radius-full);
-			border: 4px solid transparent;
-			background-clip: content-box;
-		}
+			&::-webkit-scrollbar-thumb {
+				background-color: var(--color-base-4);
+				border-radius: var(--radius-full);
+				border: 4px solid transparent;
+				background-clip: content-box;
+			}
 
-		&::-webkit-scrollbar-corner {
-			background-color: transparent;
+			&::-webkit-scrollbar-corner {
+				background-color: transparent;
+			}
 		}
 	}
 


### PR DESCRIPTION
Starting from Firefox release 153 `@supports selector(::-webkit-scrollbar)` now returns true, which broke scrollbar styling on Firefox.

This ended up being a good thing tho because my selector was wrong to begin with since `::-webkit-scrollbar` is considered legacy in ALL browsers, so I should have used a different support guard in the first place.

Now fixed. Verified in Firefox and Chrome, not verified in WebKit.