### PR TITLE
Stronghold Article: SWS26 Recap: Western Qualifier #2

### DIFF
--- a/content/articles/sws26-recap-westernqualifier2.md
+++ b/content/articles/sws26-recap-westernqualifier2.md
@@ -1,0 +1,101 @@
+---
+title: "SWS26 Recap: Western Qualifier #2"
+date: 2026-08-05
+author:
+   - name: YELLOW
+     link: https://sendou.ink/u/great-hero-yellow
+---
+
+#### *Three seats remain on the West’s plane to the global stage. Who will earn the right to join them?*
+
+<img width="1200" height="675" alt="sws26_westernqualifier2" src="https://github.com/user-attachments/assets/09cc6840-a28b-4765-b150-955f189dfef7" />
+
+On Saturday, July 25, 2026, the second and final Western qualifier in Inkling Performance Labs (IPL)’s Splat World Series 2026 events ran, with a total of 11 full teams competing for one of three last spots on the West’s roster for the main event in August. Streams were held on both IPL’s YouTube and Twitch channels. 
+
+Like its predecessor, the Western Qualifier \#2 was a double-elimination Splat Zones-only event with a strike/select system for maps, offering a layer of strategy to counterpicking during the nearly four hours of competitive Splatoon action.
+
+This time, Dark and Zach commentated throughout the entire event, with Ely operating the spectator camera. 
+
+### **Winner’s Rounds 1 and 2**
+
+The first match, a Best of Three, was between Takedown, the recent Swim or Sink 234 winners, and OwO, a pickup including a few players from BlankZ. Takedown, living up to their name, took down OwO in a fairly dominant fashion, winning 95–69 at Undertow Spillway, and getting a knockout victory at Shipshape Cargo Co. 
+
+Winner’s Round 2—the quarterfinals—saw the return of two teams from last week, Poltergeist and NOnexistenceN, and changed from a Best of Three to a Best of Five.  
+
+Across a set that went all the way to a game five, Poltergeist knocked out at Brinewater Springs and Robo ROM-en to start. NOnexistenceN tied the set by winning the next two games: a knockout at Mahi-Mahi Resort and 94–89 at Um’ami Ruins. At Barnacle & Dime, Poltergeist went the distance to stop NOnexistenceN’s reverse sweep and advanced to their qualification match. 
+
+## **Winner’s Semifinals 1: Aeternus vs. Ascension (3–2)**
+
+The first qualification match was between Aeternus and Ascension. Both were coming out of the quarterfinals after a 3–1 victory; Aeternus over Takedown, and Ascension over Thriller Bark. 
+
+Aeternus started by banning Urchin Underpass and Flounder Heights. Ascension banned Manta Maria and Bluefin Depot; the random map selection was Marlin Airport. 
+
+After two delayed wipeouts in a row, Ascension found themselves on their heels as Aeternus surged past their lead, all the way to 2 ticks remaining. Ascension inched their score closer to their opponent’s, but in the final minute, were down three players and unable to mount a defense in time to stop Aeternus from knocking out. 
+
+Aeternus’s map strikes were Humpback Pump Track and Undertow Spillway. Ascension opted to go to MakoMart for their runback, and everyone was taken by surprise to see a Custom Goo Tuber on the side of Aeternus. 
+
+<img width="1200" height="675" alt="CTuber" src="https://github.com/user-attachments/assets/aa1aaf22-d679-43d2-92e6-f4b70d74887a" />
+
+*As the match opens, Jay (in-game name: † weapon\!) is seen bringing along a Custom Goo Tuber, a weapon that the commentators weren’t sure if it had ever been seen in high level tournaments.*
+
+Jay’s Custom Goo Tuber didn’t seem like the best play for Aeternus, as they were the first player splatted in the game, leading to two delayed wipeouts in the opening minute. In the latter half of the game, Aeternus recouped enough to take the lead until they found themselves down three players, where Ascension secured control of the zone and knocked out, tying the set 1–1.
+
+For game three, Ascension struck Sturgeon Shipyard and Scorch Gorge. Hagglefish Market was Aeternus’s answer, and it was exactly what they needed. In the first minute, Aeternus wiped out Ascension, then locked Ascension out of the zone, ending the match in a win with 3:40 left on the clock. 
+
+Aeternus’s next decision was to strike Eeltail Alley and Inkblot Art Academy. Ascension returned with a Brinewater Springs selection. Early aggression got Aeternus the zone first, but they weren’t able to defend it, losing the lead before one minute had passed. Ascension made their way to 10 ticks remaining before the zone traded hands; in overtime, their lead held out, giving them the 90–84 win, once more tying the set (2–2).
+
+Game five meant after this match, the first of three final slots on the West’s team for Splat World Series would be filled. Ascension banned Mahi-Mahi Resort and Crableg Capital. Aeternus selected Barnacle & Dime as the map. 
+
+Aeternus took points by the handful; long holds of the zone gave them an early lead that Ascension struggled to catch up to. It felt like Aeternus had measured control of the game the entire time; they were the victors of the game after a knockout at 1:41, sending Ascension to the Loser’s Bracket for one final shot at a ticket to the Playoffs.
+
+## **Winner’s Semifinals 2: Content Cat vs. Poltergeist (3–1)**
+
+On the other side of the Winner’s Bracket, Content Cat and Poltergeist were ready to fight over the second to last roster slot. The first map strikes were Flounder Heights, Crableg Capital (Content Cat), Wahoo World, and Manta Maria (Poltergeist). 
+
+Game one took place at Urchin Underpass. Content Cat took the zone first and followed it up with taking Poltergeist down by three players, not just once, but twice within the span of 30 seconds. While locking Poltergeist out, Content Cat then had most of their players splatted. Despite the setback, Content Cat was able to quickly return and defend the zone, leading to a 100-to-0 knockout. 
+
+Content Cat’s next map strikes were to Eeltail Alley and Museum d’Alfonsino. The first few minutes at Um’ami Ruins were messy with zone swaps and lead changes. With a minute and a half to go, Content Cat was one point behind Poltergeist with no penalty points and the zone neutralized. After specials fired off, Content Cat was left standing to take the lead. When the clock reached zero, Content Cat was the victor, 91–77. 
+
+<img width="1200" height="675" alt="WSF_Um&#39;ami_WQ2" src="https://github.com/user-attachments/assets/ef37b147-1f1b-4f2e-a557-6b33993a2591" />
+
+*Poltergeist’s Miner takes care of Content Cat’s Chronos and Hawaiian; with Content Cat down three players, Poltergeist was at least able to avoid losing by knockout.*
+
+Brinewater Springs was the next stage after Content Cat struck Inkblot Art Academy and Marlin Airport. Content Cat continuously pushed at Poltergeist’s elbow, pressuring them back wherever possible. Poltergeist’s Booyah Bomb and Triple Inkstrikes gave them a way to cap the zone from a safe distance. The scores were quite close throughout the game, but after overtime, it was Poltergeist with the 83–81 win. 
+
+The last game was at Hagglefish Market, after Poltergeist banned MakoMart and Hammerhead Bridge. Every time Poltergeist took the zone, it was back in Content Cat’s hands before long, and they held it for longer each time. With over a minute and a half to spare, Content Cat took the knockout victory, securing the \#7 spot on the West’s Playoffs roster in a few weeks. 
+
+### **Loser’s Quarterfinals: Poltergeist vs. Takedown (2–3)**
+
+Poltergeist returned to the stream to face off against another Tri-Stringer team in Takedown. The set went all the way to game five to determine who would advance to Loser’s Semifinals for the last chance to qualify for the Splat World Series finale. 
+
+Takedown won game one at Flounder Heights. Poltergeist tied the set after knocking out at Barnacle & Dime, then followed with another knockout victory at Hagglefish Market. Takedown kept themselves alive in the set with a close 84–83 win in overtime at Urchin Underpass, leading to one last game at Mahi-Mahi Resort, where Takedown took the last victory, 83–68, in an upset from seed \#8 over seed \#3. 
+
+## **Loser’s Semifinals: Ascension vs. Takedown (3–1)**
+
+The final chance to join the West at the Splat World Series Playoffs had arrived. Ascension had just defeated NOnexistenceN 3–1 on the other side of the Loser’s Quarterfinals. Takedown had upset both seed \#4 Thriller Bark and seed \#3 Poltergeist to get this far—would they get one last upset over seed \#5?
+
+Ascension’s map strikes were Flounder Heights and Manta Maria. Takedown’s strikes were Museum d’Alfonsino and Crableg Capital. The random selection for game one was Mahi-Mahi Resort. 
+
+Takedown struggled to get down from their plat for the first minute and a half of the game; once they were able to, they took the zone from Ascension, stopping them at 14 and wiping them out. Ascension rebounded very quickly, and was able to secure game one as a knockout victory. 
+
+The next game was at MakoMart, selected by Takedown after Ascension struck Urchin Underpass and Humpback Pump Track. This one saw more back-and-forth between the teams. Halfway through, Ascension was able to get ahead of Takedown and take the lead to 11\. As the final seconds neared, Ascension stopped Takedown just shy of the lead, resulting in another Ascension win, 89–83. 
+
+Sturgeon Shipyard and Wahoo World were Ascension’s map strikes; Takedown selected Hagglefish Market. The first chunk of game three was in Takedown’s favor, able to wipe out Ascension twice. Around the 2-minute mark, Ascension took the lead, but lost it one minute later, and a handful of seconds afterward, Takedown had the win by knockout.
+
+For game four, Takedown struck Brinewater Springs and Eeltail Alley. Ascension selected Um’ami Ruins. After one minute, Ascension claimed the zone from Takedown, stopping them at 47, and from there it was a downhill ride for them. Ascension got the knockout two and a half minutes into the game, rounding out the West’s SWS26 Playoffs roster\! 
+
+<img width="1024" height="616" alt="SWSWQ2finalbracket" src="https://github.com/user-attachments/assets/b35d3d31-05a2-463d-836d-d827aaa3f585" />
+
+*The Winner’s Bracket for the Western Qualifier \#2. Since the top three teams earned their prize, the event only went up to the semifinals in both Winner’s and Loser’s brackets.* 
+
+With the Western Qualifiers coming to a close, the final three teams to ride to the Splat World Series 2026 Playoffs have been decided: Aeternus, Content Cat, and Ascension. They will join Rip pig 9, FTWin, and flower man, who were last week’s qualifier winners, and PxG and Milky Way, who were invited after the Global Gauntlet Finals wrapped up.
+
+Five teams from Japan—King of Ham, GaoGao Dragon, Vacuum World, CutieNK, Rush—are known at this time, announced at the same time as PxG and Milky Way’s invitation and on IPL’s social media. The other three JP teams will be announced in the days leading up to the SWS26 Playoffs. 
+
+When will the Playoffs take place? Day one of the two-day Playoffs start on August 7th (8 PM PT / 11 PM ET **on Friday evening** for NA; 5 AM CET / 12 PM JT **on Saturday afternoon** for non-NA). Day two for NA starts on Saturday evening on August 8th; for everyone else, it will be early in the day on Sunday, August 9th. 
+
+Don’t miss the chance to see who will join The Invincible Fleet Reimaru as the second team to crown themselves the best in the world. You will be able to see that event streamed live on IPL’s [Twitch](https://www.twitch.tv/IPLSplatoon) and [YouTube](https://www.youtube.com/@iplsplatoon) channels; AREA CUP will also have a dual stream in Japanese. 
+
+Original Posting Date: August 5, 2026 at [Splatoon Stronghold](https://www.splatoonstronghold.com/news/sws26-recap-western-qualifier-2).
+
+Written and formatted for publication by [YELLOW](https://bsky.app/profile/great-hero-yellow.bsky.social).


### PR DESCRIPTION
Add article from Splatoon Stronghold, repost of https://www.splatoonstronghold.com/news/sws26-recap-western-qualifier-2